### PR TITLE
refactor/fix: extract match service, fix dest_path escaping, Setting singleton [T-08, T-12, T-13]

### DIFF
--- a/importer/api.py
+++ b/importer/api.py
@@ -13,6 +13,7 @@ import json
 import requests
 
 from .models import Book, Setting, StatusChoices
+from .services.match import MatchEntry, MatchValidationError, process_match
 from .version import __version__ as bragibooks_version
 from utils.search_tools import ScoreTool, SearchTool
 import django
@@ -210,21 +211,20 @@ class MatchAPI(View):
     @method_decorator(ensure_csrf_cookie)
     def post(self, request):
         try:
-            # Import here to avoid circular imports
-            from .views import MatchView
-            
-            # Reuse the existing match view logic
-            match_view = MatchView()
-            match_view.request = request
-            result = match_view.post(request)
-            
-            # If it's a redirect, return success
-            if result.status_code == 302:
-                return JsonResponse({'success': True})
-            else:
-                return result
+            data = json.loads(request.body)
+            entries = [
+                MatchEntry(src_path=k, asin=v)
+                for k, v in data.items()
+                if k and v
+            ]
+            books = process_match(entries)
+            return JsonResponse({'success': True, 'books_queued': len(books)})
+        except MatchValidationError as e:
+            return JsonResponse({'error': str(e)}, status=400)
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON body'}, status=400)
         except Exception as e:
-            logger.error(f"Error in match: {e}")
+            logger.error("Unexpected error in MatchAPI.post: %s", e)
             return JsonResponse({'error': str(e)}, status=500)
 
 
@@ -248,7 +248,7 @@ class SettingsAPI(View):
         except Exception as e:
             logger.error(f"Error fetching settings: {e}")
             return JsonResponse({'error': str(e)}, status=500)
-    
+
     def post(self, request):
         try:
             data = json.loads(request.body)

--- a/importer/api.py
+++ b/importer/api.py
@@ -233,7 +233,7 @@ class SettingsAPI(View):
     
     def get(self, request):
         try:
-            settings = Setting.objects.first()
+            settings = Setting.load()
             if settings:
                 return JsonResponse({
                     'id': settings.id,
@@ -252,7 +252,7 @@ class SettingsAPI(View):
     def post(self, request):
         try:
             data = json.loads(request.body)
-            existing_settings = Setting.objects.first()
+            existing_settings = Setting.load()
             
             if existing_settings:
                 # Update existing

--- a/importer/models.py
+++ b/importer/models.py
@@ -104,3 +104,12 @@ class Setting(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     objects = SettingManager()
+
+    def save(self, *args, **kwargs):
+        self.pk = 1
+        super().save(*args, **kwargs)
+
+    @classmethod
+    def load(cls):
+        obj, _ = cls.objects.get_or_create(pk=1)
+        return obj

--- a/importer/services/match.py
+++ b/importer/services/match.py
@@ -25,7 +25,7 @@ def process_match(entries: list[MatchEntry]) -> list[Book]:
     if not entries:
         raise MatchValidationError("No entries provided")
 
-    existing_settings = Setting.objects.first()
+    existing_settings = Setting.load()
     if not existing_settings:
         raise MatchValidationError(
             "Settings not configured. Please complete setup in Settings."

--- a/importer/services/match.py
+++ b/importer/services/match.py
@@ -1,0 +1,58 @@
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from m4b_merge import helpers
+
+from importer.models import Book, Setting, StatusChoices
+from importer.tasks import m4b_merge_task
+from utils.merge import create_book
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MatchEntry:
+    src_path: str
+    asin: str
+
+
+class MatchValidationError(Exception):
+    pass
+
+
+def process_match(entries: list[MatchEntry]) -> list[Book]:
+    if not entries:
+        raise MatchValidationError("No entries provided")
+
+    existing_settings = Setting.objects.first()
+    if not existing_settings:
+        raise MatchValidationError(
+            "Settings not configured. Please complete setup in Settings."
+        )
+
+    created: list[Book] = []
+
+    for entry in entries:
+        errors = Book.objects.book_asin_validator(entry.asin)
+        if errors:
+            raise MatchValidationError(next(iter(errors.values())))
+
+        try:
+            helpers.validate_asin(existing_settings.api_url, entry.asin)
+        except ValueError:
+            raise MatchValidationError(f"Bad ASIN: {entry.asin}")
+
+        original_path = Path(entry.src_path)
+        if not helpers.get_directory(original_path):
+            logger.warning("No supported files in %s — skipping", original_path)
+            continue
+
+        logger.info("Creating book for %s at %s", entry.asin, original_path)
+        book = create_book(entry.asin, original_path)
+        created.append(book)
+
+        logger.info("Enqueuing merge task for: %s", book)
+        m4b_merge_task.enqueue(entry.asin)
+
+    return created

--- a/importer/views.py
+++ b/importer/views.py
@@ -47,7 +47,7 @@ class ImportView(LoginRequiredMixin, TemplateView):
 
     def post(self, request):
         # Redirect if this is a new session
-        existing_settings = Setting.objects.first()
+        existing_settings = Setting.load()
         if not existing_settings:
             logger.debug("No settings found, returning to settings page")
             messages.error(
@@ -101,7 +101,7 @@ class MatchView(LoginRequiredMixin, TemplateView):
                     messages.error(request, v)
                 return redirect("match")
 
-            if not (existing_settings := Setting.objects.first()):
+            if not (existing_settings := Setting.load()):
                 messages.error(request, "Settings not set")
                 return redirect("setting")
 
@@ -250,7 +250,7 @@ class SettingView(LoginRequiredMixin, TemplateView):
     template_name = "setting.html"
 
     def get_context_data(self, **kwargs):
-        existing_settings = Setting.objects.first()
+        existing_settings = Setting.load()
         default_data = {
             'api_url': 'https://api.audnex.us',
             'completed_directory': '/input/done',
@@ -263,7 +263,7 @@ class SettingView(LoginRequiredMixin, TemplateView):
             form = SettingForm(instance=existing_settings)
         else:
             form = SettingForm(initial=default_data)
-        all_settings = Setting.objects.first()
+        all_settings = Setting.load()
 
         context = {
             "form": form,
@@ -272,7 +272,7 @@ class SettingView(LoginRequiredMixin, TemplateView):
         return context
 
     def post(self, request):
-        existing_settings = Setting.objects.first()
+        existing_settings = Setting.load()
 
         form = SettingForm(request.POST)
         if form.is_valid():

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -77,13 +77,11 @@ def run_m4b_merge(asin: str):
         book.status.save()
         return
 
-    book.dest_path = Path(
-        f"\""
+    book.dest_path = (
         f"{m4b.book_output}/"
         f"{audible.fetch_api_data(config.api_url)['authors'][0]}/"
         f"{book.title}/"
         f"{book.title}.m4b"
-        f"\""
     )
     book.status.status = StatusChoices.DONE
     book.status.save()

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def set_configs():
-    existing_settings = Setting.objects.first()
+    existing_settings = Setting.load()
     if existing_settings:
         config.api_url = existing_settings.api_url
         config.junk_dir = existing_settings.completed_directory


### PR DESCRIPTION
## Summary

- **T-08** (#14): Extracts match business logic into `importer/services/match.py`. `MatchAPI.post()` no longer late-imports `MatchView` from the legacy template layer. Accepts JSON body `{src_path: asin}`.
- **T-12** (#18): Removes unnecessary `\"` escaping from `book.dest_path` in `utils/merge.py`.
- **T-13** (#19): Enforces `Setting` as a true singleton by overriding `save()` to force `pk=1` and adding a `Setting.load()` classmethod. Replaces all `Setting.objects.first()` callsites.

## Test plan

- [ ] `python manage.py check` passes with zero errors
- [ ] `POST /api/match/` with valid JSON `{"/path": "ASIN"}` returns `{"success": true, "books_queued": 1}`
- [ ] `grep -r "from .views import MatchView" importer/` returns nothing
- [ ] `book.dest_path` contains no literal `"` characters after processing
- [ ] `Setting.objects.first()` → `Setting.load()` in all Python files