### PR TITLE
feat: configuration page — field renames, help text, archive warning, Test Paths [T-05, T-06]

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -90,6 +90,11 @@ export const settingsApi = {
         await apiClient.post('/api/settings/', settings);
     },
 
+    verifyPaths: async (): Promise<Record<string, string>> => {
+        const response = await apiClient.get<Record<string, string>>('/api/settings/verify/');
+        return response.data;
+    },
+
     getVersions: async (): Promise<VersionInfo> => {
         const response = await apiClient.get<VersionInfo>('/api/versions/');
         return response.data;

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -10,7 +10,7 @@ const SettingsPage: React.FC = () => {
     const { theme, toggleTheme } = useTheme();
     const [settings, setSettings] = useState<Settings>({
         api_url: 'https://api.audnex.us',
-        completed_directory: '/input/done',
+        archive_directory: '',
         input_directory: '/input',
         num_cpus: 0,
         output_directory: '/output',
@@ -22,6 +22,8 @@ const SettingsPage: React.FC = () => {
     const [success, setSuccess] = useState(false);
     const [showUnsavedModal, setShowUnsavedModal] = useState(false);
     const [pendingNavigation, setPendingNavigation] = useState<string | null>(null);
+    const [pathStatus, setPathStatus] = useState<Record<string, string> | null>(null);
+    const [verifyLoading, setVerifyLoading] = useState(false);
 
     // Check if settings have been modified
     const isDirty = useMemo(() => {
@@ -67,6 +69,7 @@ const SettingsPage: React.FC = () => {
             await settingsApi.update(settings);
             setOriginalSettings(settings);
             setSuccess(true);
+            setPathStatus(null);
             setTimeout(() => setSuccess(false), 3000);
         } catch (err) {
             setError(getErrorMessage(err));
@@ -76,6 +79,19 @@ const SettingsPage: React.FC = () => {
     const handleChange = (field: keyof Settings, value: string | number) => {
         setSettings(prev => ({ ...prev, [field]: value }));
         setSuccess(false);
+        setPathStatus(null);
+    };
+
+    const handleVerifyPaths = async () => {
+        try {
+            setVerifyLoading(true);
+            const status = await settingsApi.verifyPaths();
+            setPathStatus(status);
+        } catch (err) {
+            setError(getErrorMessage(err));
+        } finally {
+            setVerifyLoading(false);
+        }
     };
 
     const handleSaveAndLeave = async () => {
@@ -116,6 +132,24 @@ const SettingsPage: React.FC = () => {
         }
     };
 
+    const renderPathStatus = (field: string) => {
+        if (!pathStatus || !(field in pathStatus)) return null;
+        const status = pathStatus[field];
+        if (status === 'ok') {
+            return <small className="text-success d-block mt-1"><i className="fa-solid fa-check me-1"></i>OK</small>;
+        }
+        if (status === 'missing') {
+            return <small className="text-danger d-block mt-1"><i className="fa-solid fa-xmark me-1"></i>Directory not found</small>;
+        }
+        if (status === 'not_writable') {
+            return <small className="text-warning d-block mt-1"><i className="fa-solid fa-triangle-exclamation me-1"></i>Not writable</small>;
+        }
+        if (status === 'not_configured') {
+            return <small className="text-secondary d-block mt-1">Not configured</small>;
+        }
+        return null;
+    };
+
     if (loading) {
         return (
             <div className="text-center mt-5">
@@ -131,6 +165,23 @@ const SettingsPage: React.FC = () => {
             <PageHeader
                 title="Settings"
             >
+                <button
+                    className="btn btn-outline-secondary me-2"
+                    onClick={handleVerifyPaths}
+                    disabled={verifyLoading}
+                >
+                    {verifyLoading ? (
+                        <>
+                            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                            Testing...
+                        </>
+                    ) : (
+                        <>
+                            <i className="fa-solid fa-circle-check me-2"></i>
+                            Test Paths
+                        </>
+                    )}
+                </button>
                 <button
                     className="btn btn-primary"
                     onClick={handleSave}
@@ -189,6 +240,8 @@ const SettingsPage: React.FC = () => {
                                 value={settings.input_directory}
                                 onChange={(e) => handleChange('input_directory', e.target.value)}
                             />
+                            <div className="form-text">Where your source audiobook files live</div>
+                            {renderPathStatus('input_directory')}
                         </div>
 
                         <div className="mb-3">
@@ -199,16 +252,25 @@ const SettingsPage: React.FC = () => {
                                 value={settings.output_directory}
                                 onChange={(e) => handleChange('output_directory', e.target.value)}
                             />
+                            <div className="form-text">Where finished .m4b files are written</div>
+                            {renderPathStatus('output_directory')}
                         </div>
 
                         <div className="mb-3">
-                            <label className="form-label">Completed Directory</label>
+                            <label className="form-label">Archive Directory</label>
                             <input
                                 type="text"
                                 className="form-control"
-                                value={settings.completed_directory}
-                                onChange={(e) => handleChange('completed_directory', e.target.value)}
+                                value={settings.archive_directory}
+                                onChange={(e) => handleChange('archive_directory', e.target.value)}
                             />
+                            <div className="form-text">Where source files are moved after processing (leave blank to keep in place)</div>
+                            {settings.archive_directory && settings.input_directory && settings.archive_directory.startsWith(settings.input_directory) && (
+                                <div className="alert alert-warning py-2 mb-2 mt-1" role="alert">
+                                    <small>Archive directory is inside Input directory. The app may attempt to re-process archived files.</small>
+                                </div>
+                            )}
+                            {renderPathStatus('archive_directory')}
                         </div>
 
                         <div className="mb-3">
@@ -233,7 +295,7 @@ const SettingsPage: React.FC = () => {
                                 onChange={(e) => handleChange('output_scheme', e.target.value)}
                             />
                             <div className="form-text">
-                                Use "/" for subdirectories. Supported keywords: asin, author, narrator, series_name, series_position, subtitle, title, year
+                                Available tokens: {'{author}'}, {'{title}'}, {'{series_name}'}, {'{series_position}'}, {'{subtitle}'}, {'{year}'}, {'{asin}'}, {'{narrator}'}
                             </div>
                         </div>
                     </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -57,7 +57,7 @@ export interface Status {
 export interface Settings {
     id?: number;
     api_url: string;
-    completed_directory: string;
+    archive_directory: string;
     input_directory: string;
     num_cpus: number;
     output_directory: string;

--- a/importer/api.py
+++ b/importer/api.py
@@ -238,7 +238,7 @@ class SettingsAPI(View):
                 return JsonResponse({
                     'id': settings.id,
                     'api_url': settings.api_url,
-                    'completed_directory': settings.completed_directory,
+                    'archive_directory': settings.archive_directory,
                     'input_directory': settings.input_directory,
                     'num_cpus': settings.num_cpus,
                     'output_directory': settings.output_directory,
@@ -256,7 +256,7 @@ class SettingsAPI(View):
             
             if existing_settings:
                 # Update existing
-                for field in ['api_url', 'completed_directory', 'input_directory', 
+                for field in ['api_url', 'archive_directory', 'input_directory',
                              'num_cpus', 'output_directory', 'output_scheme']:
                     if field in data:
                         setattr(existing_settings, field, data[field])
@@ -269,7 +269,7 @@ class SettingsAPI(View):
             return JsonResponse({
                 'id': settings.id,
                 'api_url': settings.api_url,
-                'completed_directory': settings.completed_directory,
+                'archive_directory': settings.archive_directory,
                 'input_directory': settings.input_directory,
                 'num_cpus': settings.num_cpus,
                 'output_directory': settings.output_directory,
@@ -277,6 +277,36 @@ class SettingsAPI(View):
             })
         except Exception as e:
             logger.error(f"Error updating settings: {e}")
+            return JsonResponse({'error': str(e)}, status=500)
+
+
+class SettingsVerifyAPI(View):
+    """Verify that configured directory paths exist and are writable."""
+
+    def get(self, request):
+        import os
+        try:
+            settings_obj = Setting.objects.first()
+            if not settings_obj:
+                return JsonResponse({'error': 'Settings not configured'}, status=400)
+
+            def check_path(path_str):
+                if not path_str:
+                    return 'not_configured'
+                p = Path(path_str)
+                if not p.is_dir():
+                    return 'missing'
+                if not os.access(p, os.W_OK):
+                    return 'not_writable'
+                return 'ok'
+
+            return JsonResponse({
+                'input_directory': check_path(settings_obj.input_directory),
+                'output_directory': check_path(settings_obj.output_directory),
+                'archive_directory': check_path(settings_obj.archive_directory),
+            })
+        except Exception as e:
+            logger.error(f"Error verifying paths: {e}")
             return JsonResponse({'error': str(e)}, status=500)
 
 

--- a/importer/forms.py
+++ b/importer/forms.py
@@ -31,7 +31,7 @@ class SettingForm(forms.ModelForm):
         model = Setting
         fields = (
             'api_url',
-            'completed_directory',
+            'archive_directory',
             'input_directory',
             'num_cpus',
             'output_directory',
@@ -39,7 +39,7 @@ class SettingForm(forms.ModelForm):
         )
         labels = {
             'api_url': 'Custom API URL',
-            'completed_directory': 'Directory for copy of original input files. Leave blank to disable moving.',
+            'archive_directory': 'Directory for copy of original input files. Leave blank to disable moving.',
             'input_directory': 'Input directory path',
             'num_cpus': 'Number of CPUs to use (0 will use all available)',
             'output_directory': 'Output directory path',
@@ -47,7 +47,7 @@ class SettingForm(forms.ModelForm):
         }
         widgets = {
             'api_url': forms.URLInput(attrs={'class': 'input is-fullwidth'}),
-            'completed_directory': forms.TextInput(attrs={'class': 'input is-fullwidth', "required": False}),
+            'archive_directory': forms.TextInput(attrs={'class': 'input is-fullwidth', "required": False}),
             'input_directory': forms.TextInput(attrs={'class': 'input is-fullwidth'}),
             'num_cpus': forms.NumberInput(attrs={'class': 'input is-fullwidth'}),
             'output_directory': forms.TextInput(attrs={'class': 'input is-fullwidth'}),

--- a/importer/migrations/0006_rename_completed_directory.py
+++ b/importer/migrations/0006_rename_completed_directory.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('importer', '0005_cover_image_link'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='setting',
+            old_name='completed_directory',
+            new_name='archive_directory',
+        ),
+        migrations.AlterField(
+            model_name='setting',
+            name='archive_directory',
+            field=models.CharField(blank=True, default='', max_length=255),
+        ),
+    ]

--- a/importer/models.py
+++ b/importer/models.py
@@ -96,7 +96,7 @@ class Narrator(models.Model):
 
 class Setting(models.Model):
     api_url = models.CharField(max_length=255)
-    completed_directory = models.CharField(max_length=255)
+    archive_directory = models.CharField(max_length=255, blank=True, default='')
     input_directory = models.CharField(max_length=255)
     num_cpus = models.IntegerField()
     output_directory = models.CharField(max_length=255)

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, re_path
 
 from .api import (
     AsinSearchAPI, BookDetailAPI, BooksListAPI, DirectoryListAPI,
-    ImportStartAPI, MatchAPI, SettingsAPI, VersionsAPI,
+    ImportStartAPI, MatchAPI, SettingsAPI, SettingsVerifyAPI, VersionsAPI,
 )
 from .auth_api import CheckSetupAPI, CurrentUserAPI, InitialSetupAPI, LoginAPI, LogoutAPI
 from .spa_view import SPAView
@@ -28,6 +28,7 @@ api_patterns = [
 
     # Settings & meta
     path('api/settings/', SettingsAPI.as_view(), name='api-settings'),
+    path('api/settings/verify/', SettingsVerifyAPI.as_view(), name='api-settings-verify'),
     path('api/versions/', VersionsAPI.as_view(), name='api-versions'),
 
     # Users

--- a/importer/views.py
+++ b/importer/views.py
@@ -253,7 +253,7 @@ class SettingView(LoginRequiredMixin, TemplateView):
         existing_settings = Setting.objects.first()
         default_data = {
             'api_url': 'https://api.audnex.us',
-            'completed_directory': '/input/done',
+            'archive_directory': '',
             'input_directory': '/input',
             'num_cpus': 0,
             'output_directory': '/output',
@@ -277,7 +277,6 @@ class SettingView(LoginRequiredMixin, TemplateView):
         form = SettingForm(request.POST)
         if form.is_valid():
             paths_to_check = [
-                'completed_directory',
                 'input_directory',
                 'output_directory'
             ]
@@ -293,7 +292,7 @@ class SettingView(LoginRequiredMixin, TemplateView):
             if not existing_settings:
                 setting = Setting.objects.create(
                     api_url=form_data['api_url'],
-                    completed_directory=form_data['completed_directory'],
+                    archive_directory=form_data['archive_directory'],
                     input_directory=form_data['input_directory'],
                     num_cpus=form_data['num_cpus'],
                     output_directory=form_data['output_directory'],
@@ -303,7 +302,7 @@ class SettingView(LoginRequiredMixin, TemplateView):
             else:
                 es = existing_settings
                 es.api_url = form_data['api_url']
-                es.completed_directory = form_data['completed_directory']
+                es.archive_directory = form_data['archive_directory']
                 es.input_directory = form_data['input_directory']
                 es.num_cpus = form_data['num_cpus']
                 es.output_directory = form_data['output_directory']

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -19,7 +19,7 @@ def set_configs():
     existing_settings = Setting.objects.first()
     if existing_settings:
         config.api_url = existing_settings.api_url
-        config.junk_dir = existing_settings.completed_directory
+        config.junk_dir = existing_settings.archive_directory
         config.num_cpus = (
             existing_settings.num_cpus if existing_settings.num_cpus > 0
             else os.cpu_count()


### PR DESCRIPTION
## Summary

- **T-05** (#11): Renames `completed_directory` → `archive_directory` throughout backend and frontend. Adds help text annotations under each directory field in ConfigurationPage. Shows an inline warning when archive directory is inside input directory. Includes migration `0006_rename_completed_directory`.
- **T-06** (#12): Adds `GET /api/settings/verify/` endpoint that checks each configured directory exists and is writable. Adds "Test Paths" button to ConfigurationPage with per-field inline status feedback.

## Test plan

- [ ] `python manage.py migrate` applies migration cleanly
- [ ] `GET /api/settings/` returns `archive_directory` field (not `completed_directory`)
- [ ] `npm run build` produces zero TypeScript errors
- [ ] ConfigurationPage shows "Archive Directory" label with help text
- [ ] Warning appears when archive dir path starts with input dir path
- [ ] "Test Paths" button shows per-field ok/missing/not_writable status
