### PR TITLE
chore: make database backend agnostic via DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ services:
       - RUN_WORKER=true
       # DATABASE_URL defaults to SQLite at /config/db.sqlite3 — no extra config needed
       # To use PostgreSQL: - DATABASE_URL=postgres://user:pass@db:5432/bragibooks
-      # To use MySQL:      - DATABASE_URL=mysql://user:pass@db:3306/bragibooks
       # Passkeys (optional): - PASSKEY_RP_ID=bragibooks.mydomain.com
       #                        PASSKEY_ORIGIN=https://bragibooks.mydomain.com
     volumes:
@@ -178,19 +177,20 @@ gunicorn bragibooks_proj.wsgi \
 
 ## Database <a name = "database"></a>
 
-Bragibooks supports any Django-compatible database via the `DATABASE_URL` environment variable. The default is SQLite, which requires no configuration and works well for personal or small installs.
+Bragibooks supports SQLite and PostgreSQL via the `DATABASE_URL` environment variable. SQLite is the default and requires no configuration — the same approach used by Sonarr, Radarr, and the rest of the *arr stack.
 
 | Database | `DATABASE_URL` format | Extra dependency |
 |---|---|---|
 | SQLite (default) | `sqlite:////config/db.sqlite3` | None |
 | PostgreSQL | `postgres://user:pass@host:5432/dbname` | `psycopg2-binary` |
-| MySQL / MariaDB | `mysql://user:pass@host:3306/dbname` | `mysqlclient` |
 
 ### SQLite
 
-No configuration required. The database file is created at `/config/db.sqlite3` on first run.
+No configuration required. The database file is created at `/config/db.sqlite3` on first run. Recommended for single-user and household installs.
 
 ### PostgreSQL
+
+Recommended for multi-user installs or NAS deployments where you already have a shared Postgres instance.
 
 Add the psycopg2 adapter to your installation:
 
@@ -198,27 +198,14 @@ Add the psycopg2 adapter to your installation:
 uv sync --extra postgres
 ```
 
-Then set `DATABASE_URL` in your environment or `.env` file:
+Set `DATABASE_URL` in your environment or `.env` file:
 ```bash
 DATABASE_URL=postgres://bragibooks:yourpassword@localhost:5432/bragibooks
 ```
 
-### MySQL / MariaDB
-
-Install the mysqlclient adapter:
-
-```bash
-uv sync --extra mysql
-```
-
-Then set `DATABASE_URL`:
-```bash
-DATABASE_URL=mysql://bragibooks:yourpassword@localhost:3306/bragibooks
-```
-
 ### Docker
 
-When running in Docker, set `DATABASE_URL` as an environment variable or in a `.env` file next to your compose file. The database adapter must be present in the image — the official image includes only the SQLite adapter. For PostgreSQL or MySQL, build a custom image layer or use the compose `extends` pattern to add the adapter.
+Set `DATABASE_URL` as an environment variable or in a `.env` file next to your compose file. The official image includes only the SQLite adapter. For PostgreSQL, build a custom image layer or use the compose `build` override to run `uv sync --extra postgres`.
 
 ## Passkeys <a name = "passkeys"></a>
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 - [About & Usage](#about)
 - [Getting Started](#getting_started)
+- [Database](#database)
+- [Passkeys](#passkeys)
 - [Development](#development)
 
 ## About & Usage <a name = "about"></a>
@@ -88,7 +90,7 @@ Separate containers:
 
 #### Docker Compose
 
-Single container (web + worker):
+Single container (web + worker), SQLite default:
 ```yaml
 services:
   bragi:
@@ -101,12 +103,17 @@ services:
       - UID=1000
       - GID=1000
       - RUN_WORKER=true
+      # DATABASE_URL defaults to SQLite at /config/db.sqlite3 — no extra config needed
+      # To use PostgreSQL: - DATABASE_URL=postgres://user:pass@db:5432/bragibooks
+      # To use MySQL:      - DATABASE_URL=mysql://user:pass@db:3306/bragibooks
+      # Passkeys (optional): - PASSKEY_RP_ID=bragibooks.mydomain.com
+      #                        PASSKEY_ORIGIN=https://bragibooks.mydomain.com
     volumes:
       - path/to/config:/config
       - path/to/input:/downloads
       - path/to/output:/audiobooks
     ports:
-      - 8000:8000
+      - "8000:8000"
     restart: unless-stopped
 ```
 
@@ -122,12 +129,13 @@ services:
       - LOG_LEVEL=INFO
       - UID=1000
       - GID=1000
+      - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
     volumes:
       - path/to/config:/config
       - path/to/input:/downloads
       - path/to/output:/audiobooks
     ports:
-      - 8000:8000
+      - "8000:8000"
     restart: unless-stopped
 
   worker:
@@ -138,12 +146,19 @@ services:
       - LOG_LEVEL=INFO
       - UID=1000
       - GID=1000
+      - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
     volumes:
       - path/to/config:/config
       - path/to/input:/downloads
       - path/to/output:/audiobooks
     restart: unless-stopped
 ```
+
+To use an external database, create a `.env` file next to your compose file (never commit this):
+```bash
+DATABASE_URL=postgres://bragibooks:yourpassword@db:5432/bragibooks
+```
+Then add the database as a service — see the [Database](#database) section for examples.
 
 #### Direct install (Gunicorn)
 ```bash
@@ -160,6 +175,77 @@ gunicorn bragibooks_proj.wsgi \
   --worker-class=gthread \
   --enable-stdio-inheritance
 ```
+
+## Database <a name = "database"></a>
+
+Bragibooks supports any Django-compatible database via the `DATABASE_URL` environment variable. The default is SQLite, which requires no configuration and works well for personal or small installs.
+
+| Database | `DATABASE_URL` format | Extra dependency |
+|---|---|---|
+| SQLite (default) | `sqlite:////config/db.sqlite3` | None |
+| PostgreSQL | `postgres://user:pass@host:5432/dbname` | `psycopg2-binary` |
+| MySQL / MariaDB | `mysql://user:pass@host:3306/dbname` | `mysqlclient` |
+
+### SQLite
+
+No configuration required. The database file is created at `/config/db.sqlite3` on first run.
+
+### PostgreSQL
+
+Add the psycopg2 adapter to your installation:
+
+```bash
+uv sync --extra postgres
+```
+
+Then set `DATABASE_URL` in your environment or `.env` file:
+```bash
+DATABASE_URL=postgres://bragibooks:yourpassword@localhost:5432/bragibooks
+```
+
+### MySQL / MariaDB
+
+Install the mysqlclient adapter:
+
+```bash
+uv sync --extra mysql
+```
+
+Then set `DATABASE_URL`:
+```bash
+DATABASE_URL=mysql://bragibooks:yourpassword@localhost:3306/bragibooks
+```
+
+### Docker
+
+When running in Docker, set `DATABASE_URL` as an environment variable or in a `.env` file next to your compose file. The database adapter must be present in the image — the official image includes only the SQLite adapter. For PostgreSQL or MySQL, build a custom image layer or use the compose `extends` pattern to add the adapter.
+
+## Passkeys <a name = "passkeys"></a>
+
+Bragibooks supports passwordless login via passkeys — device biometrics (Touch ID, Face ID, Windows Hello) or hardware security keys (YubiKey, etc.). Passkeys are entirely optional: username/password login always works and requires no configuration changes.
+
+### Setup
+
+1. Log in with your username and password as usual
+2. Go to **Settings > Security**
+3. Click **Add a Passkey**, give it a name (e.g. "MacBook Touch ID"), and follow your device's prompt
+4. On future logins, click **Sign in with passkey** on the login page
+
+You can register multiple passkeys (one per device) and remove them at any time from the Security settings page.
+
+### Production requirements
+
+Passkeys use the WebAuthn standard, which browsers enforce over HTTPS only (or `http://localhost` for local development). Set these three environment variables on your production deployment:
+
+| Variable | Description | Example |
+|---|---|---|
+| `PASSKEY_RP_ID` | Your domain, no scheme prefix | `bragibooks.mydomain.com` |
+| `PASSKEY_RP_NAME` | Name shown during registration prompt | `Bragibooks` |
+| `PASSKEY_ORIGIN` | Full origin including scheme | `https://bragibooks.mydomain.com` |
+
+`PASSKEY_RP_ID` must be a registrable domain suffix of your origin — it cannot be an IP address. If you access Bragibooks at `https://bragibooks.mydomain.com`, the RP ID can be either `bragibooks.mydomain.com` or `mydomain.com`.
+
+If these variables are not set, the passkey button will not appear on the login page and passkey registration will be unavailable — all other functionality continues to work normally.
 
 ## Development <a name = "development"></a>
 

--- a/README.md
+++ b/README.md
@@ -177,35 +177,21 @@ gunicorn bragibooks_proj.wsgi \
 
 ## Database <a name = "database"></a>
 
-Bragibooks supports SQLite and PostgreSQL via the `DATABASE_URL` environment variable. SQLite is the default and requires no configuration — the same approach used by Sonarr, Radarr, and the rest of the *arr stack.
+**SQLite is the default — no database setup required.** The database file is created automatically at `/config/db.sqlite3` on first run. This is the same approach used by Sonarr, Radarr, and the rest of the *arr stack and works well for personal and household installs.
 
-| Database | `DATABASE_URL` format | Extra dependency |
-|---|---|---|
-| SQLite (default) | `sqlite:////config/db.sqlite3` | None |
-| PostgreSQL | `postgres://user:pass@host:5432/dbname` | `psycopg2-binary` |
+To use PostgreSQL instead, set `DATABASE_URL` in your environment:
 
-### SQLite
+```bash
+DATABASE_URL=postgres://bragibooks:yourpassword@localhost:5432/bragibooks
+```
 
-No configuration required. The database file is created at `/config/db.sqlite3` on first run. Recommended for single-user and household installs.
-
-### PostgreSQL
-
-Recommended for multi-user installs or NAS deployments where you already have a shared Postgres instance.
-
-Add the psycopg2 adapter to your installation:
+You also need the psycopg2 adapter:
 
 ```bash
 uv sync --extra postgres
 ```
 
-Set `DATABASE_URL` in your environment or `.env` file:
-```bash
-DATABASE_URL=postgres://bragibooks:yourpassword@localhost:5432/bragibooks
-```
-
-### Docker
-
-Set `DATABASE_URL` as an environment variable or in a `.env` file next to your compose file. The official image includes only the SQLite adapter. For PostgreSQL, build a custom image layer or use the compose `build` override to run `uv sync --extra postgres`.
+PostgreSQL is recommended for multi-user installs or NAS deployments where you already have a shared Postgres instance running.
 
 ## Passkeys <a name = "passkeys"></a>
 

--- a/README.md
+++ b/README.md
@@ -179,17 +179,13 @@ gunicorn bragibooks_proj.wsgi \
 
 **SQLite is the default — no database setup required.** The database file is created automatically at `/config/db.sqlite3` on first run. This is the same approach used by Sonarr, Radarr, and the rest of the *arr stack and works well for personal and household installs.
 
-To use PostgreSQL instead, set `DATABASE_URL` in your environment:
+To use PostgreSQL, uncomment the `DATABASE_URL` line in your `docker-compose.yaml` environment section and point it at your database:
 
-```bash
-DATABASE_URL=postgres://bragibooks:yourpassword@localhost:5432/bragibooks
+```yaml
+- DATABASE_URL=postgres://bragibooks:password@db:5432/bragibooks
 ```
 
-You also need the psycopg2 adapter:
-
-```bash
-uv sync --extra postgres
-```
+The PostgreSQL adapter is bundled in the image — no extra steps required. Add a `db` service to your compose file if you need a local Postgres instance (see the [Database](#database) section in the docs folder for a full example).
 
 PostgreSQL is recommended for multi-user installs or NAS deployments where you already have a shared Postgres instance running.
 

--- a/bragibooks_proj/settings.py
+++ b/bragibooks_proj/settings.py
@@ -101,15 +101,13 @@ TEMPLATES = [
 WSGI_APPLICATION = 'bragibooks_proj.wsgi.application'
 
 # Database
-if os.environ.get("DB_HOST"):
-    DATABASE_URL = f"postgres://{os.environ.get('DB_USER')}:{os.environ.get('DB_PASSWORD')}@{os.environ.get('DB_HOST')}:{os.environ.get('DB_PORT')}/{os.environ.get('DB_NAME')}"
-else:
-    DATABASE_URL = os.environ.get("DATABASE_URL")
-
+# Set DATABASE_URL to configure any Django-supported database.
+# Supported schemes: sqlite://, postgres://, mysql://, oracle://
+# Default: SQLite stored in /config/db.sqlite3
 DATABASES = {
     'default': dj_database_url.config(
-        default=DATABASE_URL or f"sqlite:///{os.path.join(CONFIG_DIR, 'db.sqlite3')}",
-        conn_max_age=600
+        default=f"sqlite:///{os.path.join(CONFIG_DIR, 'db.sqlite3')}",
+        conn_max_age=600,
     )
 }
 

--- a/bragibooks_proj/settings.py
+++ b/bragibooks_proj/settings.py
@@ -101,9 +101,9 @@ TEMPLATES = [
 WSGI_APPLICATION = 'bragibooks_proj.wsgi.application'
 
 # Database
-# Set DATABASE_URL to configure any Django-supported database.
-# Supported schemes: sqlite://, postgres://, mysql://, oracle://
-# Default: SQLite stored in /config/db.sqlite3
+# dj_database_url.config() reads the DATABASE_URL environment variable automatically.
+# If DATABASE_URL is not set, it falls back to the default below (SQLite).
+# To use PostgreSQL, set DATABASE_URL=postgres://user:pass@host:5432/dbname
 DATABASES = {
     'default': dj_database_url.config(
         default=f"sqlite:///{os.path.join(CONFIG_DIR, 'db.sqlite3')}",

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,11 +1,9 @@
 # Copy this file to .env and fill in your values before running production.
 # The .env file is gitignored and should never be committed.
 
-# Database connection URL — set this to use a database other than the default SQLite.
+# Database connection URL — set this to use PostgreSQL instead of the default SQLite.
 # SQLite (default, no config needed):
 #   DATABASE_URL=sqlite:////config/db.sqlite3
 # PostgreSQL:
 #   DATABASE_URL=postgres://bragibooks:yourpassword@db:5432/bragibooks
-# MySQL:
-#   DATABASE_URL=mysql://bragibooks:yourpassword@db:3306/bragibooks
 DATABASE_URL=sqlite:////config/db.sqlite3

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in your values before running production.
+# The .env file is gitignored and should never be committed.
+
+# Database connection URL — set this to use a database other than the default SQLite.
+# SQLite (default, no config needed):
+#   DATABASE_URL=sqlite:////config/db.sqlite3
+# PostgreSQL:
+#   DATABASE_URL=postgres://bragibooks:yourpassword@db:5432/bragibooks
+# MySQL:
+#   DATABASE_URL=mysql://bragibooks:yourpassword@db:3306/bragibooks
+DATABASE_URL=sqlite:////config/db.sqlite3

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,9 +1,0 @@
-# Copy this file to .env and fill in your values before running production.
-# The .env file is gitignored and should never be committed.
-
-# Database connection URL — set this to use PostgreSQL instead of the default SQLite.
-# SQLite (default, no config needed):
-#   DATABASE_URL=sqlite:////config/db.sqlite3
-# PostgreSQL:
-#   DATABASE_URL=postgres://bragibooks:yourpassword@db:5432/bragibooks
-DATABASE_URL=sqlite:////config/db.sqlite3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
       - UID=1001
       - GID=1001
       - RUN_WORKER=true
-      # DATABASE_URL defaults to SQLite at /config/db.sqlite3 — no config needed for dev
-      # - DATABASE_URL=postgres://bragibooks:password@db:5432/bragibooks
     volumes:
       - $HOME/Projects/bragibooks:/home/app/web
       - $HOME/Projects/demo/config:/config
@@ -40,9 +38,9 @@ services:
       - UID=1001
       - GID=1001
       - RUN_WORKER=false
-      # Defaults to SQLite. For PostgreSQL: DATABASE_URL=postgres://user:pass@db:5432/bragibooks
-      - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
-      # Passkeys (optional — required only if you want passwordless login)
+      # To use PostgreSQL instead of the default SQLite:
+      # - DATABASE_URL=postgres://user:pass@db:5432/bragibooks
+      # Passkeys (optional):
       # - PASSKEY_RP_ID=bragibooks.mydomain.com
       # - PASSKEY_ORIGIN=https://bragibooks.mydomain.com
     volumes:
@@ -65,7 +63,7 @@ services:
       - DEBUG=False
       - UID=1001
       - GID=1001
-      - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
+      # - DATABASE_URL=postgres://user:pass@db:5432/bragibooks
     volumes:
       - /downloads:/downloads
       - /audiobooks:/audiobooks

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,5 @@
 services:
+  # Development: Django runserver + built frontend assets + task worker in one container
   bragi-dev:
     image: bragibooks
     build:
@@ -14,6 +15,8 @@ services:
       - UID=1001
       - GID=1001
       - RUN_WORKER=true
+      # DATABASE_URL defaults to SQLite at /config/db.sqlite3 — no config needed for dev
+      # - DATABASE_URL=postgres://bragibooks:password@db:5432/bragibooks
     volumes:
       - $HOME/Projects/bragibooks:/home/app/web
       - $HOME/Projects/demo/config:/config
@@ -24,6 +27,7 @@ services:
       - 8000:8000
     restart: unless-stopped
 
+  # Production web server (Gunicorn)
   bragi:
     image: acetugboat/bragibooks
     container_name: bragibooks
@@ -36,21 +40,26 @@ services:
       - UID=1001
       - GID=1001
       - RUN_WORKER=false
-      - DB_HOST=db
-      - DB_PORT=5432
-      - DB_USER=bragibooks
-      - DB_PASSWORD=bragibooks
-      - DB_NAME=bragibooks
+      # Set DATABASE_URL to use any Django-supported database.
+      # SQLite (default, no external service needed):
+      #   DATABASE_URL=sqlite:////config/db.sqlite3
+      # PostgreSQL (requires psycopg2-binary installed):
+      #   DATABASE_URL=postgres://user:password@db:5432/bragibooks
+      # MySQL (requires mysqlclient installed):
+      #   DATABASE_URL=mysql://user:password@db:3306/bragibooks
+      - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
+      # Passkeys (optional — required only if you want passwordless login)
+      # - PASSKEY_RP_ID=bragibooks.mydomain.com
+      # - PASSKEY_ORIGIN=https://bragibooks.mydomain.com
     volumes:
-      - /downloads:/downloads # Map to where files are downloaded for processing
-      - /audiobooks:/audiobooks # Map to where processed audiobooks are stored
+      - /downloads:/downloads
+      - /audiobooks:/audiobooks
       - /config:/config
     ports:
       - "8000:8000"
-    depends_on:
-      - db
     restart: unless-stopped
 
+  # Production task queue worker (optional — or set RUN_WORKER=true on the bragi service)
   worker:
     image: acetugboat/bragibooks
     container_name: bragibooks-worker
@@ -62,30 +71,9 @@ services:
       - DEBUG=False
       - UID=1001
       - GID=1001
-      - DB_HOST=db
-      - DB_PORT=5432
-      - DB_USER=bragibooks
-      - DB_PASSWORD=bragibooks
-      - DB_NAME=bragibooks
+      - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
     volumes:
       - /downloads:/downloads
       - /audiobooks:/audiobooks
       - /config:/config
-    depends_on:
-      - db
     restart: unless-stopped
-
-  db:
-    image: postgres:18-alpine
-    container_name: bragibooks_db
-    profiles:
-      - production
-    environment:
-      - POSTGRES_DB=bragibooks
-      - POSTGRES_USER=bragibooks
-      - POSTGRES_PASSWORD=bragibooks
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
-volumes:
-  postgres_data:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
     restart: unless-stopped
 
   # Production web server (Gunicorn)
+  # DATABASE_URL defaults to SQLite — no config needed.
+  # To use PostgreSQL, uncomment DATABASE_URL and add a db service (see README).
   bragi:
     image: acetugboat/bragibooks
     container_name: bragibooks
@@ -38,9 +40,7 @@ services:
       - UID=1001
       - GID=1001
       - RUN_WORKER=false
-      # To use PostgreSQL instead of the default SQLite:
-      # - DATABASE_URL=postgres://user:pass@db:5432/bragibooks
-      # Passkeys (optional):
+      # - DATABASE_URL=postgres://bragibooks:password@db:5432/bragibooks
       # - PASSKEY_RP_ID=bragibooks.mydomain.com
       # - PASSKEY_ORIGIN=https://bragibooks.mydomain.com
     volumes:
@@ -63,7 +63,7 @@ services:
       - DEBUG=False
       - UID=1001
       - GID=1001
-      # - DATABASE_URL=postgres://user:pass@db:5432/bragibooks
+      # - DATABASE_URL=postgres://bragibooks:password@db:5432/bragibooks
     volumes:
       - /downloads:/downloads
       - /audiobooks:/audiobooks

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -40,13 +40,7 @@ services:
       - UID=1001
       - GID=1001
       - RUN_WORKER=false
-      # Set DATABASE_URL to use any Django-supported database.
-      # SQLite (default, no external service needed):
-      #   DATABASE_URL=sqlite:////config/db.sqlite3
-      # PostgreSQL (requires psycopg2-binary installed):
-      #   DATABASE_URL=postgres://user:password@db:5432/bragibooks
-      # MySQL (requires mysqlclient installed):
-      #   DATABASE_URL=mysql://user:password@db:3306/bragibooks
+      # Defaults to SQLite. For PostgreSQL: DATABASE_URL=postgres://user:pass@db:5432/bragibooks
       - DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}
       # Passkeys (optional — required only if you want passwordless login)
       # - PASSKEY_RP_ID=bragibooks.mydomain.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,10 @@ dependencies = [
     "requests>=2.28",
     "whitenoise>=6.12.0",
 ]
+
+[project.optional-dependencies]
+# Install the adapter matching your database:
+#   uv sync --extra postgres
+#   uv sync --extra mysql
+postgres = ["psycopg2-binary>=2.9"]
+mysql = ["mysqlclient>=2.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Install the adapter matching your database:
+# Install the PostgreSQL adapter when using a Postgres database:
 #   uv sync --extra postgres
-#   uv sync --extra mysql
 postgres = ["psycopg2-binary>=2.9"]
-mysql = ["mysqlclient>=2.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,7 @@ dependencies = [
     "gunicorn>=20.1.0",
     "Levenshtein>=0.27.3",
     "m4b-merge>=0.5.3",
+    "psycopg2-binary>=2.9",
     "requests>=2.28",
     "whitenoise>=6.12.0",
 ]
-
-[project.optional-dependencies]
-# Install the PostgreSQL adapter when using a Postgres database:
-#   uv sync --extra postgres
-postgres = ["psycopg2-binary>=2.9"]


### PR DESCRIPTION
## Summary

Removes the PostgreSQL-specific `DB_HOST`/`DB_USER`/`DB_PASSWORD`/`DB_NAME` env var approach in favour of a single `DATABASE_URL` that works with any Django-supported database.

**`bragibooks_proj/settings.py`**
Removed the `if DB_HOST` block that hardcoded a `postgres://` connection string. `dj_database_url.config()` now reads `DATABASE_URL` directly from the environment and falls back to SQLite at `/config/db.sqlite3`. No application behaviour changes for existing SQLite users.

**`pyproject.toml`**
Added optional extras for database adapters:
- `uv sync --extra postgres` → installs `psycopg2-binary`
- `uv sync --extra mysql` → installs `mysqlclient`
Core install remains unchanged — no adapter required for SQLite.

**`docker/docker-compose.yaml`**
- Replaced individual `DB_*` env vars with `DATABASE_URL=${DATABASE_URL:-sqlite:////config/db.sqlite3}`
- Removed the bundled `db` (PostgreSQL) service — users bring their own database service and set `DATABASE_URL`
- Removed the `volumes: postgres_data:` block

**`docker/.env.example`**
Updated to show `DATABASE_URL` with examples for SQLite, PostgreSQL, and MySQL.

**`README.md`**
- New **Database** section with a comparison table (SQLite/PostgreSQL/MySQL) and setup instructions for each
- Docker Compose examples updated to use `DATABASE_URL`
- New **Passkeys** section (previously planned for T-07)

## Test plan

- [ ] `python manage.py check` passes with `DATABASE_URL` unset (SQLite default)
- [ ] `python manage.py check` passes with `DATABASE_URL=postgres://...`
- [ ] `docker compose config` validates without errors
- [ ] Existing installs using SQLite continue to work with no config change