### PR TITLE
fix(build): add setuptools package discovery config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
     "requests>=2.28",
     "whitenoise>=6.12.0",
 ]
+
+[tool.setuptools.packages.find]
+include = ["importer*", "bragibooks_proj*", "utils*"]


### PR DESCRIPTION
setuptools auto-discovery was finding every top-level directory (input, docker, config, static, frontend) and refusing to build. Adds `[tool.setuptools.packages.find]` with an explicit include list so only the actual Python packages (importer, bragibooks_proj, utils) are picked up. Fixes `pip install .` and ensures `uv sync` without `--no-install-project` also works.