### PR TITLE
feat: reprocess / retry failed books [T-18]

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -66,6 +66,10 @@ export const bookApi = {
     delete: async (id: string | number): Promise<void> => {
         await apiClient.delete(`/api/books/${id}/`);
     },
+
+    reprocess: async (id: string | number, asin?: string): Promise<void> => {
+        await apiClient.post(`/api/books/${id}/reprocess/`, asin ? { asin } : {});
+    },
 };
 
 // ASIN Search

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import type { Book } from '../types';
+import { StatusChoice } from '../types';
 import { bookApi, getErrorMessage } from '../api/services';
 import { useData } from '../context/DataContext';
 
@@ -14,6 +15,9 @@ const BookDetailPage: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [showReprocessModal, setShowReprocessModal] = useState(false);
+    const [reprocessAsin, setReprocessAsin] = useState('');
+    const [reprocessing, setReprocessing] = useState(false);
     const { refreshBooks } = useData();
 
     useEffect(() => {
@@ -53,8 +57,22 @@ const BookDetailPage: React.FC = () => {
         }
     };
 
+    const handleReprocess = async () => {
+        try {
+            setReprocessing(true);
+            await bookApi.reprocess(id!, reprocessAsin || undefined);
+            await refreshBooks();
+            setShowReprocessModal(false);
+            setReprocessAsin('');
+            if (id) loadBook(id);
+        } catch (err) {
+            setError(getErrorMessage(err));
+        } finally {
+            setReprocessing(false);
+        }
+    };
+
     const handleFixMetadata = () => {
-        // TODO: Implement fix metadata functionality
         console.log('Fix metadata for book:', id);
     };
 
@@ -112,6 +130,16 @@ const BookDetailPage: React.FC = () => {
                 }
             >
                 <div className="d-flex gap-2">
+                    {book.status.status === StatusChoice.DONE && (
+                        <button
+                            className="btn btn-outline-warning btn-sm"
+                            onClick={() => setShowReprocessModal(true)}
+                            title="Re-process"
+                        >
+                            <i className="fa-solid fa-rotate me-1"></i>
+                            Re-process
+                        </button>
+                    )}
                     <button
                         className="btn btn-outline-danger btn-sm"
                         onClick={() => setShowDeleteModal(true)}
@@ -320,6 +348,60 @@ const BookDetailPage: React.FC = () => {
                         </div>
                     </div>
                 </div>
+        )}
+
+        {showReprocessModal && (
+            <div className="modal d-block" tabIndex={-1} style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+                <div className="modal-dialog">
+                    <div className="modal-content">
+                        <div className="modal-header">
+                            <h5 className="modal-title">Re-process Book</h5>
+                            <button
+                                type="button"
+                                className="btn-close"
+                                onClick={() => setShowReprocessModal(false)}
+                                disabled={reprocessing}
+                            />
+                        </div>
+                        <div className="modal-body">
+                            <p>Re-processing will overwrite the existing output file for <strong>{book.title}</strong>.</p>
+                            <div className="mb-3">
+                                <label className="form-label small text-muted">New ASIN (leave blank to retry with same ASIN)</label>
+                                <input
+                                    type="text"
+                                    className="form-control"
+                                    placeholder={book.asin}
+                                    value={reprocessAsin}
+                                    onChange={e => setReprocessAsin(e.target.value)}
+                                />
+                            </div>
+                        </div>
+                        <div className="modal-footer">
+                            <button
+                                type="button"
+                                className="btn btn-secondary"
+                                onClick={() => setShowReprocessModal(false)}
+                                disabled={reprocessing}
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                className="btn btn-warning"
+                                onClick={handleReprocess}
+                                disabled={reprocessing}
+                            >
+                                {reprocessing ? (
+                                    <>
+                                        <span className="spinner-border spinner-border-sm me-2" role="status" />
+                                        Re-processing...
+                                    </>
+                                ) : 'Re-process'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         )}
         </>
     );

--- a/frontend/src/pages/ProcessingPage.tsx
+++ b/frontend/src/pages/ProcessingPage.tsx
@@ -1,11 +1,29 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import { useData } from '../context/DataContext';
+import { bookApi, getErrorMessage } from '../api/services';
 
 const ProcessingPage: React.FC = () => {
     const { books, refreshBooks } = useData();
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const [reprocessingId, setReprocessingId] = useState<number | null>(null);
+    const [reprocessAsin, setReprocessAsin] = useState('');
+    const [reprocessError, setReprocessError] = useState<string | null>(null);
+
+    const handleReprocess = async (bookId: number, asin?: string) => {
+        try {
+            setReprocessingId(bookId);
+            setReprocessError(null);
+            await bookApi.reprocess(bookId, asin || undefined);
+            await refreshBooks();
+        } catch (err) {
+            setReprocessError(getErrorMessage(err));
+        } finally {
+            setReprocessingId(null);
+            setReprocessAsin('');
+        }
+    };
 
     useEffect(() => {
         if (books.processing.length > 0) {
@@ -59,8 +77,8 @@ const ProcessingPage: React.FC = () => {
                     <div className="list-group">
                         {books.error.map(book => (
                             <div key={book.id} className="list-group-item">
-                                <div className="d-flex justify-content-between align-items-start">
-                                    <div>
+                                <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                                    <div className="flex-grow-1">
                                         <strong>{book.title}</strong>
                                         {book.authors[0] && (
                                             <span className="text-muted ms-2">
@@ -68,16 +86,31 @@ const ProcessingPage: React.FC = () => {
                                             </span>
                                         )}
                                         {book.status.message && (
-                                            <p className="text-danger small mb-0 mt-1">{book.status.message}</p>
+                                            <p className="text-danger small mb-1 mt-1">{book.status.message}</p>
                                         )}
-                                    </div>
-                                    <div className="d-flex gap-2 ms-3 flex-shrink-0">
-                                        <button className="btn btn-sm btn-outline-primary" disabled>
-                                            Re-process
-                                        </button>
-                                        <button className="btn btn-sm btn-outline-danger" disabled>
-                                            Delete
-                                        </button>
+                                        {reprocessError && reprocessingId === book.id && (
+                                            <p className="text-danger small mb-0">{reprocessError}</p>
+                                        )}
+                                        <div className="d-flex gap-2 mt-2 align-items-center flex-wrap">
+                                            <input
+                                                type="text"
+                                                className="form-control form-control-sm"
+                                                style={{ maxWidth: 160 }}
+                                                placeholder="New ASIN (optional)"
+                                                value={reprocessingId === book.id ? reprocessAsin : ''}
+                                                onChange={e => setReprocessAsin(e.target.value)}
+                                                onFocus={() => setReprocessingId(book.id)}
+                                            />
+                                            <button
+                                                className="btn btn-sm btn-outline-primary"
+                                                disabled={reprocessingId === book.id && reprocessAsin === '' && false}
+                                                onClick={() => handleReprocess(book.id, reprocessAsin || undefined)}
+                                            >
+                                                {reprocessingId === book.id ? (
+                                                    <span className="spinner-border spinner-border-sm" role="status" />
+                                                ) : 'Re-process'}
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/importer/api/books.py
+++ b/importer/api/books.py
@@ -1,8 +1,10 @@
+import json
 import logging
 from django.http import JsonResponse
 from django.views import View
 
 from ..models import Book, StatusChoices
+from ..tasks import m4b_merge_task
 from .mixins import JsonLoginRequiredMixin
 
 logger = logging.getLogger(__name__)
@@ -95,3 +97,36 @@ class BookDetailAPI(JsonLoginRequiredMixin, View):
         except Exception as e:
             logger.error("Error deleting book %s: %s", pk, e)
             return JsonResponse({'error': str(e)}, status=500)
+
+
+class BookReprocessAPI(JsonLoginRequiredMixin, View):
+    def post(self, request, pk):
+        try:
+            data = json.loads(request.body) if request.body else {}
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON body'}, status=400)
+
+        try:
+            book = Book.objects.select_related('status').get(pk=pk)
+        except Book.DoesNotExist:
+            return JsonResponse({'error': 'Book not found'}, status=404)
+
+        new_asin = data.get('asin', '').strip()
+        if new_asin:
+            errors = Book.objects.book_asin_validator(new_asin)
+            if errors:
+                return JsonResponse({'error': next(iter(errors.values()))}, status=400)
+            book.asin = new_asin
+            book.save(update_fields=['asin'])
+
+        book.status.status = StatusChoices.PROCESSING
+        book.status.message = ''
+        book.status.save()
+
+        try:
+            m4b_merge_task.enqueue(book.asin)
+        except Exception as e:
+            logger.error("Failed to enqueue reprocess for book %s: %s", pk, e)
+            return JsonResponse({'error': 'Failed to enqueue task'}, status=500)
+
+        return JsonResponse({'success': True, 'asin': book.asin})

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 
 from .api.auth import CheckSetupAPI, CurrentUserAPI, InitialSetupAPI, LoginAPI, LogoutAPI
-from .api.books import BookDetailAPI, BooksListAPI
+from .api.books import BookDetailAPI, BookReprocessAPI, BooksListAPI
 from .api.config import SettingsAPI, SettingsVerifyAPI, VersionsAPI
 from .api.import_pipeline import AsinSearchAPI, DirectoryListAPI, ImportStartAPI, MatchAPI
 from .api.users import UserDetailAPI, UsersListAPI
@@ -18,6 +18,7 @@ api_patterns = [
     # Books
     path('api/books/', BooksListAPI.as_view(), name='api-books'),
     path('api/books/<int:pk>/', BookDetailAPI.as_view(), name='api-book-detail'),
+    path('api/books/<int:pk>/reprocess/', BookReprocessAPI.as_view(), name='api-book-reprocess'),
 
     # Import / match
     path('api/match/', MatchAPI.as_view(), name='api-match'),


### PR DESCRIPTION
## Summary
- `POST /api/books/<id>/reprocess/` resets status to PROCESSING and re-enqueues the merge task; accepts optional `{ "asin": "..." }` to retry with a different ASIN
- ProcessingPage error cards: Re-process button now active with optional ASIN input per card
- BookDetailPage: Re-process button shown for DONE books with overwrite warning modal

## Test plan
- [ ] On ProcessingPage, expand an error card and click Re-process (no ASIN) — book moves to Processing
- [ ] Enter a different ASIN in the input, click Re-process — book retries with new ASIN
- [ ] On a DONE book's detail page, Re-process button appears; modal shows overwrite warning
- [ ] Cancel dismisses without action

Closes #24