### PR TITLE
feat(frontend): DataContext polling + toast notifications [T-19]

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,15 +15,19 @@ import LoginPage from './pages/LoginPage';
 import SetupPage from './pages/SetupPage';
 import { ThemeProvider } from './context/ThemeContext';
 import { AuthProvider } from './context/AuthContext';
+import { useData } from './context/DataContext';
+import ToastContainer from './components/ToastContainer';
 
 // Layout component with sidebar (for authenticated pages)
 const Layout: React.FC = () => {
+  const { toasts, dismissToast } = useData();
   return (
     <ErrorBoundary>
       <Sidebar />
       <div className="main-content">
         <Outlet />
       </div>
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </ErrorBoundary>
   );
 };

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export interface Toast {
+    id: number;
+    type: 'done' | 'error';
+    bookId: number;
+    title: string;
+}
+
+interface ToastContainerProps {
+    toasts: Toast[];
+    onDismiss: (id: number) => void;
+}
+
+const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, onDismiss }) => {
+    if (toasts.length === 0) return null;
+
+    return (
+        <div
+            className="toast-container position-fixed bottom-0 end-0 p-3"
+            style={{ zIndex: 1100 }}
+        >
+            {toasts.map(toast => (
+                <div
+                    key={toast.id}
+                    className={`toast show align-items-center text-bg-${toast.type === 'done' ? 'success' : 'danger'} border-0 mb-2`}
+                    role="alert"
+                    aria-live="assertive"
+                >
+                    <div className="d-flex">
+                        <div className="toast-body">
+                            {toast.type === 'done' ? (
+                                <>
+                                    <i className="fa-solid fa-check me-2"></i>
+                                    <Link
+                                        to={`/books/${toast.bookId}`}
+                                        className="text-white fw-semibold"
+                                        style={{ textDecoration: 'underline' }}
+                                    >
+                                        {toast.title}
+                                    </Link>
+                                    {' '}is ready
+                                </>
+                            ) : (
+                                <>
+                                    <i className="fa-solid fa-xmark me-2"></i>
+                                    <Link
+                                        to="/processing"
+                                        className="text-white fw-semibold"
+                                        style={{ textDecoration: 'underline' }}
+                                    >
+                                        {toast.title}
+                                    </Link>
+                                    {' '}failed — view details
+                                </>
+                            )}
+                        </div>
+                        <button
+                            type="button"
+                            className="btn-close btn-close-white me-2 m-auto"
+                            aria-label="Close"
+                            onClick={() => onDismiss(toast.id)}
+                        />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default ToastContainer;

--- a/frontend/src/context/DataContext.tsx
+++ b/frontend/src/context/DataContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef, useCallback, type ReactNode } from 'react';
 import { bookApi, settingsApi, getErrorMessage } from '../api/services';
 import type { Book, Settings, VersionInfo } from '../types';
+import type { Toast } from '../components/ToastContainer';
 
 interface BooksData {
     done: Book[];
@@ -16,44 +17,66 @@ interface DataContextType {
     loadingSettings: boolean;
     errorBooks: string | null;
     errorSettings: string | null;
+    toasts: Toast[];
     refreshBooks: () => Promise<void>;
     refreshSettings: () => Promise<void>;
+    dismissToast: (id: number) => void;
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
 
 export const useData = () => {
     const context = useContext(DataContext);
-    if (!context) {
-        throw new Error('useData must be used within a DataProvider');
-    }
+    if (!context) throw new Error('useData must be used within a DataProvider');
     return context;
 };
 
-interface DataProviderProps {
-    children: ReactNode;
-}
+let toastCounter = 0;
 
-export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
+export const DataProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     const [books, setBooks] = useState<BooksData>({ done: [], processing: [], error: [] });
     const [settings, setSettings] = useState<Settings | null>(null);
     const [versions, setVersions] = useState<VersionInfo | null>(null);
-
     const [loadingBooks, setLoadingBooks] = useState(true);
     const [loadingSettings, setLoadingSettings] = useState(true);
-
     const [errorBooks, setErrorBooks] = useState<string | null>(null);
     const [errorSettings, setErrorSettings] = useState<string | null>(null);
+    const [toasts, setToasts] = useState<Toast[]>([]);
 
-    useEffect(() => {
-        refreshBooks();
-        refreshSettings();
+    const prevProcessingRef = useRef<Book[]>([]);
+
+    const dismissToast = useCallback((id: number) => {
+        setToasts(prev => prev.filter(t => t.id !== id));
     }, []);
 
-    const refreshBooks = async () => {
+    const refreshBooks = useCallback(async () => {
         try {
             setLoadingBooks(true);
             const data = await bookApi.getAll();
+
+            // Detect PROCESSING → DONE or ERROR transitions
+            const prevIds = new Set(prevProcessingRef.current.map(b => b.id));
+            const prevById = new Map(prevProcessingRef.current.map(b => [b.id, b]));
+            const nowDoneIds = new Set(data.done.map(b => b.id));
+            const nowErrorIds = new Set(data.error.map(b => b.id));
+
+            const newToasts: Toast[] = [];
+            for (const id of prevIds) {
+                const prev = prevById.get(id)!;
+                if (nowDoneIds.has(id)) {
+                    newToasts.push({ id: ++toastCounter, type: 'done', bookId: id, title: prev.title });
+                } else if (nowErrorIds.has(id)) {
+                    newToasts.push({ id: ++toastCounter, type: 'error', bookId: id, title: prev.title });
+                }
+            }
+            if (newToasts.length > 0) {
+                setToasts(prev => [...prev, ...newToasts]);
+                newToasts.forEach(t => {
+                    setTimeout(() => dismissToast(t.id), 8000);
+                });
+            }
+
+            prevProcessingRef.current = data.processing;
             setBooks(data);
             setErrorBooks(null);
         } catch (err) {
@@ -61,9 +84,9 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
         } finally {
             setLoadingBooks(false);
         }
-    };
+    }, [dismissToast]);
 
-    const refreshSettings = async () => {
+    const refreshSettings = useCallback(async () => {
         try {
             setLoadingSettings(true);
             const [settingsData, versionsData] = await Promise.all([
@@ -78,19 +101,31 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
         } finally {
             setLoadingSettings(false);
         }
-    };
+    }, []);
 
-    const value = {
-        books,
-        settings,
-        versions,
-        loadingBooks,
-        loadingSettings,
-        errorBooks,
-        errorSettings,
-        refreshBooks,
-        refreshSettings,
-    };
+    // Initial load
+    useEffect(() => {
+        refreshBooks();
+        refreshSettings();
+    }, []);
 
-    return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
+    // Poll every 10s while books are processing
+    useEffect(() => {
+        if (books.processing.length > 0) {
+            const interval = setInterval(refreshBooks, 10_000);
+            return () => clearInterval(interval);
+        }
+    }, [books.processing.length, refreshBooks]);
+
+    return (
+        <DataContext.Provider value={{
+            books, settings, versions,
+            loadingBooks, loadingSettings,
+            errorBooks, errorSettings,
+            toasts, refreshBooks, refreshSettings, dismissToast,
+        }}>
+            {children}
+        </DataContext.Provider>
+    );
 };
+

--- a/frontend/src/pages/ProcessingPage.tsx
+++ b/frontend/src/pages/ProcessingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import { useData } from '../context/DataContext';
@@ -6,7 +6,6 @@ import { bookApi, getErrorMessage } from '../api/services';
 
 const ProcessingPage: React.FC = () => {
     const { books, refreshBooks } = useData();
-    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const [reprocessingId, setReprocessingId] = useState<number | null>(null);
     const [reprocessAsin, setReprocessAsin] = useState('');
     const [reprocessError, setReprocessError] = useState<string | null>(null);
@@ -24,15 +23,6 @@ const ProcessingPage: React.FC = () => {
             setReprocessAsin('');
         }
     };
-
-    useEffect(() => {
-        if (books.processing.length > 0) {
-            intervalRef.current = setInterval(refreshBooks, 10_000);
-        }
-        return () => {
-            if (intervalRef.current) clearInterval(intervalRef.current);
-        };
-    }, [books.processing.length, refreshBooks]);
 
     const recentlyCompleted = [...books.done]
         .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())


### PR DESCRIPTION
## Summary
- DataContext polls `/api/books/` every 10s when books are processing; stops automatically when nothing is in-flight
- Detects PROCESSING → DONE and PROCESSING → ERROR transitions; shows Bootstrap 5 toast with a link to the book or processing page
- Toasts auto-dismiss after 8 seconds
- Removed redundant polling `setInterval` from `ProcessingPage` (DataContext now owns it)

## Test plan
- [ ] Start processing a book; observe 10s poll cycle in network tab
- [ ] When processing completes, a green toast appears with a link to the book detail page
- [ ] When processing errors, a red toast appears with a link to `/processing`
- [ ] Toast dismisses automatically after 8s or via the close button
- [ ] When no books are processing, no poll requests fire

Closes #25