### PR TITLE
feat(settings): expose m4b processing options via API and model

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -62,6 +62,12 @@ export interface Settings {
     num_cpus: number;
     output_directory: string;
     output_scheme: string;
+    skip_conversion?: boolean;
+    audio_bitrate?: number | null;
+    audio_samplerate?: number | null;
+    chapter_source?: 'audible' | 'source_file';
+    ignore_source_tags?: boolean;
+    chapter_name_format?: string;
 }
 
 // File explorer types

--- a/importer/api/config.py
+++ b/importer/api/config.py
@@ -28,6 +28,12 @@ class SettingsAPI(JsonLoginRequiredMixin, View):
                     'num_cpus': s.num_cpus,
                     'output_directory': s.output_directory,
                     'output_scheme': s.output_scheme,
+                    'skip_conversion': s.skip_conversion,
+                    'audio_bitrate': s.audio_bitrate,
+                    'audio_samplerate': s.audio_samplerate,
+                    'chapter_source': s.chapter_source,
+                    'ignore_source_tags': s.ignore_source_tags,
+                    'chapter_name_format': s.chapter_name_format,
                 })
             return JsonResponse(None, safe=False)
         except Exception as e:
@@ -42,7 +48,9 @@ class SettingsAPI(JsonLoginRequiredMixin, View):
             s = Setting.load()
             if s:
                 for field in ['api_url', 'archive_directory', 'input_directory',
-                              'num_cpus', 'output_directory', 'output_scheme']:
+                              'num_cpus', 'output_directory', 'output_scheme',
+                              'skip_conversion', 'audio_bitrate', 'audio_samplerate',
+                              'chapter_source', 'ignore_source_tags', 'chapter_name_format']:
                     if field in data:
                         setattr(s, field, data[field])
                 s.save()
@@ -56,6 +64,12 @@ class SettingsAPI(JsonLoginRequiredMixin, View):
                 'num_cpus': s.num_cpus,
                 'output_directory': s.output_directory,
                 'output_scheme': s.output_scheme,
+                'skip_conversion': s.skip_conversion,
+                'audio_bitrate': s.audio_bitrate,
+                'audio_samplerate': s.audio_samplerate,
+                'chapter_source': s.chapter_source,
+                'ignore_source_tags': s.ignore_source_tags,
+                'chapter_name_format': s.chapter_name_format,
             })
         except Exception as e:
             logger.error("Error updating settings: %s", e)

--- a/importer/migrations/0007_add_m4b_processing_options.py
+++ b/importer/migrations/0007_add_m4b_processing_options.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('importer', '0006_rename_completed_directory'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='setting',
+            name='skip_conversion',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='setting',
+            name='audio_bitrate',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='setting',
+            name='audio_samplerate',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='setting',
+            name='chapter_source',
+            field=models.CharField(
+                max_length=20,
+                choices=[('audible', 'Audible'), ('source_file', 'Source File')],
+                default='audible',
+            ),
+        ),
+        migrations.AddField(
+            model_name='setting',
+            name='ignore_source_tags',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='setting',
+            name='chapter_name_format',
+            field=models.CharField(max_length=255, blank=True, default=''),
+        ),
+    ]

--- a/importer/models.py
+++ b/importer/models.py
@@ -101,6 +101,16 @@ class Setting(models.Model):
     num_cpus = models.IntegerField()
     output_directory = models.CharField(max_length=255)
     output_scheme = models.CharField(max_length=255)
+    skip_conversion = models.BooleanField(default=False)
+    audio_bitrate = models.IntegerField(null=True, blank=True)
+    audio_samplerate = models.IntegerField(null=True, blank=True)
+    chapter_source = models.CharField(
+        max_length=20,
+        choices=[('audible', 'Audible'), ('source_file', 'Source File')],
+        default='audible',
+    )
+    ignore_source_tags = models.BooleanField(default=False)
+    chapter_name_format = models.CharField(max_length=255, blank=True, default='')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     objects = SettingManager()


### PR DESCRIPTION
## Summary

- Adds six new `Setting` model fields for m4b processing control: `skip_conversion`, `audio_bitrate`, `audio_samplerate`, `chapter_source`, `ignore_source_tags`, `chapter_name_format`
- Migration `0007_add_m4b_processing_options` to create the columns
- `SettingsAPI` GET and POST now include all six fields
- Frontend `Settings` type extended with the new optional fields

Closes #27