### PR TITLE
feat(auth): passkey frontend — SecurityPage + login button [T-11]

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import UserManagementPage from './pages/UserManagementPage';
 import AboutPage from './pages/AboutPage';
 import LoginPage from './pages/LoginPage';
 import SetupPage from './pages/SetupPage';
+import SecurityPage from './pages/SecurityPage';
 import { ThemeProvider } from './context/ThemeContext';
 import { AuthProvider } from './context/AuthContext';
 import { useData } from './context/DataContext';
@@ -78,7 +79,7 @@ const router = createBrowserRouter([
           },
           {
             path: 'settings/security',
-            element: <ProcessingPage />, // placeholder until T-11 wires it
+            element: <SecurityPage />,
           },
           {
             path: 'settings/users',

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -5,6 +5,7 @@ import type {
     DirectoryContents,
     AsinSearchResult,
     VersionInfo,
+    PasskeyCredential,
 } from '../types';
 
 export interface User {
@@ -141,6 +142,37 @@ export const authApi = {
             email,
         });
         return response.data;
+    },
+};
+
+// Passkey (WebAuthn) operations
+export const passkeyApi = {
+    list: async (): Promise<PasskeyCredential[]> => {
+        const response = await apiClient.get<PasskeyCredential[]>('/api/auth/passkeys/');
+        return response.data;
+    },
+
+    registerBegin: async (): Promise<any> => {
+        const response = await apiClient.get('/api/auth/passkey/register/begin/');
+        return response.data;
+    },
+
+    registerComplete: async (credential: any): Promise<void> => {
+        await apiClient.post('/api/auth/passkey/register/complete/', credential);
+    },
+
+    loginBegin: async (): Promise<any> => {
+        const response = await apiClient.get('/api/auth/passkey/login/begin/');
+        return response.data;
+    },
+
+    loginComplete: async (assertion: any): Promise<User> => {
+        const response = await apiClient.post<User>('/api/auth/passkey/login/complete/', assertion);
+        return response.data;
+    },
+
+    delete: async (id: number): Promise<void> => {
+        await apiClient.delete(`/api/auth/passkeys/${id}/`);
     },
 };
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { getErrorMessage } from '../api/services';
+import { passkeyApi, getErrorMessage } from '../api/services';
+import { startAuthentication } from '../utils/webauthn';
 
 const LoginPage: React.FC = () => {
     const navigate = useNavigate();
-    const { login } = useAuth();
+    const { login, checkAuth } = useAuth();
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
+    const [passkeyLoading, setPasskeyLoading] = useState(false);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -23,6 +25,22 @@ const LoginPage: React.FC = () => {
             setError(getErrorMessage(err));
         } finally {
             setLoading(false);
+        }
+    };
+
+    const handlePasskeyLogin = async () => {
+        setError(null);
+        setPasskeyLoading(true);
+        try {
+            const options = await passkeyApi.loginBegin();
+            const assertion = await startAuthentication(options);
+            await passkeyApi.loginComplete(assertion);
+            await checkAuth();
+            navigate('/');
+        } catch (err) {
+            setError(getErrorMessage(err));
+        } finally {
+            setPasskeyLoading(false);
         }
     };
 
@@ -91,6 +109,29 @@ const LoginPage: React.FC = () => {
                             )}
                         </button>
                     </form>
+
+                    {window.PublicKeyCredential && (
+                        <div className="mt-3">
+                            <div className="d-flex align-items-center gap-2 mb-3">
+                                <hr className="flex-grow-1" />
+                                <small className="text-muted">or</small>
+                                <hr className="flex-grow-1" />
+                            </div>
+                            <button
+                                type="button"
+                                className="btn btn-outline-secondary w-100"
+                                onClick={handlePasskeyLogin}
+                                disabled={passkeyLoading || loading}
+                            >
+                                {passkeyLoading ? (
+                                    <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+                                ) : (
+                                    <i className="fa-solid fa-key me-2" />
+                                )}
+                                Sign in with a passkey
+                            </button>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect } from 'react';
+import PageHeader from '../components/PageHeader';
+import type { PasskeyCredential } from '../types';
+import { passkeyApi, getErrorMessage } from '../api/services';
+import { startRegistration } from '../utils/webauthn';
+
+const SecurityPage: React.FC = () => {
+    const [passkeys, setPasskeys] = useState<PasskeyCredential[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [newName, setNewName] = useState('');
+    const [registering, setRegistering] = useState(false);
+    const [deleteId, setDeleteId] = useState<number | null>(null);
+    const webauthnSupported = !!window.PublicKeyCredential;
+
+    const loadPasskeys = async () => {
+        try {
+            const data = await passkeyApi.list();
+            setPasskeys(data);
+        } catch (err) {
+            setError(getErrorMessage(err));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { loadPasskeys(); }, []);
+
+    const handleRegister = async () => {
+        setError(null);
+        setRegistering(true);
+        try {
+            const options = await passkeyApi.registerBegin();
+            const credential = await startRegistration(options, newName || 'My Passkey');
+            await passkeyApi.registerComplete(credential);
+            setNewName('');
+            await loadPasskeys();
+        } catch (err) {
+            setError(getErrorMessage(err));
+        } finally {
+            setRegistering(false);
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        try {
+            await passkeyApi.delete(id);
+            setDeleteId(null);
+            await loadPasskeys();
+        } catch (err) {
+            setError(getErrorMessage(err));
+        }
+    };
+
+    return (
+        <>
+            <PageHeader title="Security" />
+            <div className="container-fluid px-4 py-3">
+                {error && (
+                    <div className="alert alert-danger alert-dismissible" role="alert">
+                        {error}
+                        <button type="button" className="btn-close" onClick={() => setError(null)} />
+                    </div>
+                )}
+
+                {!webauthnSupported && (
+                    <div className="alert alert-warning" role="alert">
+                        <i className="fa-solid fa-triangle-exclamation me-2" />
+                        Your browser does not support passkeys (WebAuthn). Use a modern browser to register a passkey.
+                    </div>
+                )}
+
+                <div className="card mb-3">
+                    <div className="card-body">
+                        <h5 className="card-title mb-4">Registered Passkeys</h5>
+                        {loading ? (
+                            <div className="text-center py-3">
+                                <div className="spinner-border" role="status" />
+                            </div>
+                        ) : passkeys.length === 0 ? (
+                            <p className="text-muted">No passkeys registered yet.</p>
+                        ) : (
+                            <ul className="list-group list-group-flush mb-3">
+                                {passkeys.map(pk => (
+                                    <li key={pk.id} className="list-group-item d-flex align-items-center justify-content-between">
+                                        <div>
+                                            <div className="fw-semibold">{pk.name || 'Unnamed'}</div>
+                                            <small className="text-muted">
+                                                Added {new Date(pk.created_at).toLocaleDateString()}
+                                                {pk.last_used_at && ` · Last used ${new Date(pk.last_used_at).toLocaleDateString()}`}
+                                            </small>
+                                        </div>
+                                        <button
+                                            className="btn btn-sm btn-outline-danger"
+                                            onClick={() => setDeleteId(pk.id)}
+                                        >
+                                            <i className="fa-solid fa-trash" />
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+
+                        {webauthnSupported && (
+                            <div className="mt-3">
+                                <h6>Add a Passkey</h6>
+                                <div className="input-group" style={{ maxWidth: 400 }}>
+                                    <input
+                                        type="text"
+                                        className="form-control"
+                                        placeholder="Passkey name (e.g. MacBook)"
+                                        value={newName}
+                                        onChange={e => setNewName(e.target.value)}
+                                        disabled={registering}
+                                    />
+                                    <button
+                                        className="btn btn-primary"
+                                        onClick={handleRegister}
+                                        disabled={registering}
+                                    >
+                                        {registering ? (
+                                            <span className="spinner-border spinner-border-sm" />
+                                        ) : 'Register'}
+                                    </button>
+                                </div>
+                                <small className="text-muted d-block mt-1">
+                                    Your browser will prompt you to authenticate with a biometric or device PIN.
+                                </small>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {deleteId !== null && (
+                <div className="modal d-block" tabIndex={-1} style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+                    <div className="modal-dialog">
+                        <div className="modal-content">
+                            <div className="modal-header">
+                                <h5 className="modal-title">Remove Passkey</h5>
+                                <button type="button" className="btn-close" onClick={() => setDeleteId(null)} />
+                            </div>
+                            <div className="modal-body">
+                                <p>Are you sure you want to remove this passkey? You will no longer be able to sign in with it.</p>
+                            </div>
+                            <div className="modal-footer">
+                                <button className="btn btn-secondary" onClick={() => setDeleteId(null)}>Cancel</button>
+                                <button className="btn btn-danger" onClick={() => handleDelete(deleteId)}>Remove</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+};
+
+export default SecurityPage;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -111,3 +111,10 @@ export interface VersionInfo {
     django_version: string;
     m4b_merge_version: string;
 }
+
+export interface PasskeyCredential {
+    id: number;
+    name: string;
+    created_at: string;
+    last_used_at: string | null;
+}

--- a/frontend/src/utils/webauthn.ts
+++ b/frontend/src/utils/webauthn.ts
@@ -1,0 +1,69 @@
+function base64urlToUint8Array(b64url: string): Uint8Array {
+    const padded = b64url.replace(/-/g, '+').replace(/_/g, '/')
+        + '=='.slice(0, (4 - b64url.length % 4) % 4);
+    const binary = atob(padded);
+    return Uint8Array.from(binary, c => c.charCodeAt(0));
+}
+
+function uint8ArrayToBase64url(buf: ArrayBuffer | Uint8Array): string {
+    const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    return btoa(String.fromCharCode(...bytes))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+export async function startRegistration(options: any, name: string): Promise<any> {
+    const publicKey: PublicKeyCredentialCreationOptions = {
+        ...options,
+        challenge: base64urlToUint8Array(options.challenge),
+        user: {
+            ...options.user,
+            id: base64urlToUint8Array(options.user.id),
+        },
+        excludeCredentials: (options.excludeCredentials ?? []).map((c: any) => ({
+            ...c,
+            id: base64urlToUint8Array(c.id),
+        })),
+    };
+
+    const credential = await navigator.credentials.create({ publicKey }) as PublicKeyCredential;
+    const attestation = credential.response as AuthenticatorAttestationResponse;
+
+    return {
+        id: credential.id,
+        rawId: uint8ArrayToBase64url(credential.rawId),
+        type: credential.type,
+        name,
+        response: {
+            clientDataJSON: uint8ArrayToBase64url(attestation.clientDataJSON),
+            attestationObject: uint8ArrayToBase64url(attestation.attestationObject),
+        },
+    };
+}
+
+export async function startAuthentication(options: any): Promise<any> {
+    const publicKey: PublicKeyCredentialRequestOptions = {
+        ...options,
+        challenge: base64urlToUint8Array(options.challenge),
+        allowCredentials: (options.allowCredentials ?? []).map((c: any) => ({
+            ...c,
+            id: base64urlToUint8Array(c.id),
+        })),
+    };
+
+    const assertion = await navigator.credentials.get({ publicKey }) as PublicKeyCredential;
+    const assertionResp = assertion.response as AuthenticatorAssertionResponse;
+
+    return {
+        id: assertion.id,
+        rawId: uint8ArrayToBase64url(assertion.rawId),
+        type: assertion.type,
+        response: {
+            clientDataJSON: uint8ArrayToBase64url(assertionResp.clientDataJSON),
+            authenticatorData: uint8ArrayToBase64url(assertionResp.authenticatorData),
+            signature: uint8ArrayToBase64url(assertionResp.signature),
+            userHandle: assertionResp.userHandle
+                ? uint8ArrayToBase64url(assertionResp.userHandle)
+                : null,
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- `frontend/src/utils/webauthn.ts`: base64url ↔ Uint8Array converters, `startRegistration()` and `startAuthentication()` wrappers for browser WebAuthn API
- `SecurityPage`: lists passkeys with name/date, register form, delete with confirmation modal
- LoginPage: 'Sign in with a passkey' button (only rendered when `window.PublicKeyCredential` exists)
- `/settings/security` now serves `SecurityPage` (previously a placeholder pointing at `ProcessingPage`)

## Test plan
- [ ] On a modern browser, go to /settings/security — passkey list visible
- [ ] Register a passkey — browser prompts, appears in list after success
- [ ] Log out — 'Sign in with a passkey' button visible on login page
- [ ] Click it — browser challenge appears, logs in on success
- [ ] On a browser without WebAuthn — warning shown on SecurityPage, button hidden on LoginPage
- [ ] Delete a passkey — confirmation modal appears, removed from list on confirm

Closes #17