### PR TITLE
feat(books): metadata editor for completed books [T-24]

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -72,6 +72,14 @@ export const bookApi = {
     reprocess: async (id: string | number, asin?: string): Promise<void> => {
         await apiClient.post(`/api/books/${id}/reprocess/`, asin ? { asin } : {});
     },
+
+    updateMetadata: async (id: string | number, data: {
+        title?: string; author?: string; narrator?: string;
+        year?: number; description?: string; genre?: string;
+    }): Promise<Book> => {
+        const response = await apiClient.put<Book>(`/api/books/${id}/metadata/`, data);
+        return response.data;
+    },
 };
 
 // ASIN Search

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
-import type { Book } from '../types';
+import type { Author, Book, Narrator } from '../types';
 import { StatusChoice } from '../types';
 import { bookApi, getErrorMessage } from '../api/services';
 import { useData } from '../context/DataContext';
@@ -18,6 +18,9 @@ const BookDetailPage: React.FC = () => {
     const [showReprocessModal, setShowReprocessModal] = useState(false);
     const [reprocessAsin, setReprocessAsin] = useState('');
     const [reprocessing, setReprocessing] = useState(false);
+    const [showMetaModal, setShowMetaModal] = useState(false);
+    const [metaForm, setMetaForm] = useState({ title: '', author: '', narrator: '', year: '', description: '', genre: '' });
+    const [savingMeta, setSavingMeta] = useState(false);
     const { refreshBooks } = useData();
 
     useEffect(() => {
@@ -73,7 +76,36 @@ const BookDetailPage: React.FC = () => {
     };
 
     const handleFixMetadata = () => {
-        console.log('Fix metadata for book:', id);
+        setMetaForm({
+            title: book?.title ?? '',
+            author: book?.authors?.map((a: Author) => `${a.first_name} ${a.last_name}`).join(', ') ?? '',
+            narrator: book?.narrators?.map((n: Narrator) => `${n.first_name} ${n.last_name}`).join(', ') ?? '',
+            year: '',
+            description: book?.long_desc ?? book?.short_desc ?? '',
+            genre: '',
+        });
+        setShowMetaModal(true);
+    };
+
+    const handleSaveMeta = async () => {
+        if (!id || !book) return;
+        setSavingMeta(true);
+        try {
+            const updated = await bookApi.updateMetadata(id, {
+                title: metaForm.title || undefined,
+                author: metaForm.author || undefined,
+                narrator: metaForm.narrator || undefined,
+                year: metaForm.year ? parseInt(metaForm.year, 10) : undefined,
+                description: metaForm.description || undefined,
+                genre: metaForm.genre || undefined,
+            });
+            setBook(updated);
+            setShowMetaModal(false);
+        } catch (err) {
+            setError(getErrorMessage(err));
+        } finally {
+            setSavingMeta(false);
+        }
     };
 
     if (loading) {
@@ -397,6 +429,55 @@ const BookDetailPage: React.FC = () => {
                                         Re-processing...
                                     </>
                                 ) : 'Re-process'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )}
+
+        {showMetaModal && book && (
+            <div className="modal d-block" tabIndex={-1} style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+                <div className="modal-dialog modal-lg">
+                    <div className="modal-content">
+                        <div className="modal-header">
+                            <h5 className="modal-title">Edit Metadata</h5>
+                            <button type="button" className="btn-close" onClick={() => setShowMetaModal(false)} disabled={savingMeta} />
+                        </div>
+                        <div className="modal-body">
+                            <p className="text-muted small mb-3">Changes are written directly to the .m4b file tags.</p>
+                            {[
+                                { key: 'title', label: 'Title' },
+                                { key: 'author', label: 'Author(s)' },
+                                { key: 'narrator', label: 'Narrator(s)' },
+                                { key: 'year', label: 'Year', type: 'number' },
+                                { key: 'genre', label: 'Genre' },
+                            ].map(({ key, label, type }) => (
+                                <div className="mb-3" key={key}>
+                                    <label className="form-label">{label}</label>
+                                    <input
+                                        type={type ?? 'text'}
+                                        className="form-control"
+                                        value={metaForm[key as keyof typeof metaForm]}
+                                        onChange={e => setMetaForm(prev => ({ ...prev, [key]: e.target.value }))}
+                                    />
+                                </div>
+                            ))}
+                            <div className="mb-3">
+                                <label className="form-label">Description</label>
+                                <textarea
+                                    className="form-control"
+                                    rows={4}
+                                    value={metaForm.description}
+                                    onChange={e => setMetaForm(prev => ({ ...prev, description: e.target.value }))}
+                                />
+                            </div>
+                        </div>
+                        <div className="modal-footer">
+                            <button className="btn btn-secondary" onClick={() => setShowMetaModal(false)} disabled={savingMeta}>Cancel</button>
+                            <button className="btn btn-primary" onClick={handleSaveMeta} disabled={savingMeta}>
+                                {savingMeta ? <span className="spinner-border spinner-border-sm me-2" role="status" /> : null}
+                                Save to File
                             </button>
                         </div>
                     </div>

--- a/importer/api/books.py
+++ b/importer/api/books.py
@@ -1,5 +1,8 @@
 import json
 import logging
+import shutil
+import subprocess
+from pathlib import Path
 from django.http import JsonResponse
 from django.views import View
 
@@ -130,3 +133,54 @@ class BookReprocessAPI(JsonLoginRequiredMixin, View):
             return JsonResponse({'error': 'Failed to enqueue task'}, status=500)
 
         return JsonResponse({'success': True, 'asin': book.asin})
+
+
+class BookMetadataAPI(JsonLoginRequiredMixin, View):
+    def put(self, request, pk):
+        try:
+            book = Book.objects.get(pk=pk)
+        except Book.DoesNotExist:
+            return JsonResponse({'error': 'Book not found'}, status=404)
+
+        if not book.dest_path:
+            return JsonResponse({'error': 'Book has no output file'}, status=400)
+        if not Path(book.dest_path).exists():
+            return JsonResponse({'error': 'Output file not found on disk'}, status=400)
+
+        try:
+            data = json.loads(request.body)
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON body'}, status=400)
+
+        m4b_tool = shutil.which('m4b-tool')
+        if not m4b_tool:
+            return JsonResponse({'error': 'm4b-tool not available'}, status=503)
+
+        args = [m4b_tool, 'meta']
+        if data.get('title'):
+            args += [f"--name={data['title']}", f"--album={data['title']}"]
+            book.title = data['title']
+        if data.get('author'):
+            args.append(f"--albumartist={data['author']}")
+        if data.get('narrator'):
+            args.append(f"--artist={data['narrator']}")
+        if data.get('year'):
+            args.append(f"--year={data['year']}")
+        if data.get('description'):
+            args.append(f"--description={data['description']}")
+        if data.get('genre'):
+            args.append(f"--genre={data['genre']}")
+        args.append(book.dest_path)
+
+        try:
+            result = subprocess.run(args, capture_output=True, timeout=60)
+            if result.returncode != 0:
+                err_out = result.stderr.decode(errors='replace')
+                return JsonResponse({'error': f'm4b-tool failed: {err_out}'}, status=500)
+        except subprocess.TimeoutExpired:
+            return JsonResponse({'error': 'm4b-tool timed out'}, status=500)
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)
+
+        book.save()
+        return JsonResponse(serialize_book(book))

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -6,7 +6,7 @@ from .api.auth import (
     PasskeyLoginBeginAPI, PasskeyLoginCompleteAPI,
     PasskeyRegisterBeginAPI, PasskeyRegisterCompleteAPI,
 )
-from .api.books import BookDetailAPI, BookReprocessAPI, BooksListAPI
+from .api.books import BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI
 from .api.config import SettingsAPI, SettingsVerifyAPI, VersionsAPI
 from .api.import_pipeline import AsinSearchAPI, DirectoryListAPI, ImportStartAPI, MatchAPI
 from .api.users import UserDetailAPI, UsersListAPI
@@ -32,6 +32,7 @@ api_patterns = [
     path('api/books/', BooksListAPI.as_view(), name='api-books'),
     path('api/books/<int:pk>/', BookDetailAPI.as_view(), name='api-book-detail'),
     path('api/books/<int:pk>/reprocess/', BookReprocessAPI.as_view(), name='api-book-reprocess'),
+    path('api/books/<int:pk>/metadata/', BookMetadataAPI.as_view(), name='api-book-metadata'),
 
     # Import / match
     path('api/match/', MatchAPI.as_view(), name='api-match'),


### PR DESCRIPTION
## Summary
- `PUT /api/books/<id>/metadata/` runs `m4b-tool meta` to update embedded tags; updates `book.title` in DB when title is changed
- 'Fix Metadata' button on BookDetailPage now opens a pre-filled modal (title, author, narrator, year, description, genre)
- Returns 503 if `m4b-tool` binary is not available (Docker image has it; local dev may not)

## Test plan
- [ ] On a DONE book with a dest_path, click 'Fix Metadata'
- [ ] Change title and save — verify title updates in UI and verify embedded tag with `m4b-tool meta --print`
- [ ] Cancel — no changes
- [ ] Book with no dest_path — button should be absent or returns 400

Closes #30