### PR TITLE
feat(books): chapter editor for completed books [T-25]

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -1,6 +1,7 @@
 import apiClient from './client';
 import type {
     Book,
+    Chapter,
     Settings,
     DirectoryContents,
     AsinSearchResult,
@@ -79,6 +80,15 @@ export const bookApi = {
     }): Promise<Book> => {
         const response = await apiClient.put<Book>(`/api/books/${id}/metadata/`, data);
         return response.data;
+    },
+
+    getChapters: async (id: string | number): Promise<Chapter[]> => {
+        const response = await apiClient.get<Chapter[]>(`/api/books/${id}/chapters/`);
+        return response.data;
+    },
+
+    saveChapters: async (id: string | number, chapters: Chapter[]): Promise<void> => {
+        await apiClient.put(`/api/books/${id}/chapters/`, chapters);
     },
 };
 

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
-import type { Author, Book, Narrator } from '../types';
+import type { Author, Book, Chapter, Narrator } from '../types';
 import { StatusChoice } from '../types';
 import { bookApi, getErrorMessage } from '../api/services';
 import { useData } from '../context/DataContext';
@@ -21,6 +21,11 @@ const BookDetailPage: React.FC = () => {
     const [showMetaModal, setShowMetaModal] = useState(false);
     const [metaForm, setMetaForm] = useState({ title: '', author: '', narrator: '', year: '', description: '', genre: '' });
     const [savingMeta, setSavingMeta] = useState(false);
+    const [chapters, setChapters] = useState<Chapter[]>([]);
+    const [chaptersOpen, setChaptersOpen] = useState(false);
+    const [loadingChapters, setLoadingChapters] = useState(false);
+    const [savingChapters, setSavingChapters] = useState(false);
+    const [chapterError, setChapterError] = useState<string | null>(null);
     const { refreshBooks } = useData();
 
     useEffect(() => {
@@ -85,6 +90,35 @@ const BookDetailPage: React.FC = () => {
             genre: '',
         });
         setShowMetaModal(true);
+    };
+
+    const handleLoadChapters = async () => {
+        if (!id) return;
+        setChaptersOpen(o => !o);
+        if (!chaptersOpen && chapters.length === 0) {
+            setLoadingChapters(true);
+            try {
+                const data = await bookApi.getChapters(id);
+                setChapters(data);
+            } catch (err) {
+                setChapterError(getErrorMessage(err));
+            } finally {
+                setLoadingChapters(false);
+            }
+        }
+    };
+
+    const handleSaveChapters = async () => {
+        if (!id) return;
+        setSavingChapters(true);
+        try {
+            await bookApi.saveChapters(id, chapters);
+            setChapterError(null);
+        } catch (err) {
+            setChapterError(getErrorMessage(err));
+        } finally {
+            setSavingChapters(false);
+        }
     };
 
     const handleSaveMeta = async () => {
@@ -331,6 +365,79 @@ const BookDetailPage: React.FC = () => {
                                     </div>
                                 </div>
                             </div>
+
+                            {/* Chapters (DONE books only) */}
+                            {book.status.status === StatusChoice.DONE && (
+                                <div className="col-12 mt-3">
+                                    <div className="card">
+                                        <div
+                                            className="card-header d-flex align-items-center justify-content-between"
+                                            style={{ cursor: 'pointer' }}
+                                            onClick={handleLoadChapters}
+                                        >
+                                            <h5 className="mb-0">
+                                                <i className="fa-solid fa-list-ol me-2" />
+                                                Chapters
+                                            </h5>
+                                            <i className={`fas fa-angle-${chaptersOpen ? 'up' : 'down'}`} />
+                                        </div>
+                                        {chaptersOpen && (
+                                            <div className="card-body">
+                                                {chapterError && (
+                                                    <div className="alert alert-danger">{chapterError}</div>
+                                                )}
+                                                {loadingChapters ? (
+                                                    <div className="text-center py-3"><div className="spinner-border" /></div>
+                                                ) : chapters.length === 0 ? (
+                                                    <p className="text-muted">No chapters found.</p>
+                                                ) : (
+                                                    <>
+                                                        <div className="table-responsive">
+                                                            <table className="table table-sm">
+                                                                <thead>
+                                                                    <tr>
+                                                                        <th style={{ width: 50 }}>#</th>
+                                                                        <th style={{ width: 130 }}>Timestamp</th>
+                                                                        <th>Name</th>
+                                                                    </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                                    {chapters.map((ch, i) => (
+                                                                        <tr key={i}>
+                                                                            <td className="text-muted">{ch.index}</td>
+                                                                            <td><code className="small">{ch.timestamp}</code></td>
+                                                                            <td>
+                                                                                <input
+                                                                                    type="text"
+                                                                                    className="form-control form-control-sm"
+                                                                                    value={ch.name}
+                                                                                    onChange={e => setChapters(prev => {
+                                                                                        const next = [...prev];
+                                                                                        next[i] = { ...next[i], name: e.target.value };
+                                                                                        return next;
+                                                                                    })}
+                                                                                />
+                                                                            </td>
+                                                                        </tr>
+                                                                    ))}
+                                                                </tbody>
+                                                            </table>
+                                                        </div>
+                                                        <button
+                                                            className="btn btn-primary btn-sm"
+                                                            onClick={handleSaveChapters}
+                                                            disabled={savingChapters}
+                                                        >
+                                                            {savingChapters ? <span className="spinner-border spinner-border-sm me-1" role="status" /> : null}
+                                                            Save Chapters
+                                                        </button>
+                                                    </>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     </div>
                 </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -118,3 +118,9 @@ export interface PasskeyCredential {
     created_at: string;
     last_used_at: string | null;
 }
+
+export interface Chapter {
+    index: number;
+    timestamp: string;
+    name: string;
+}

--- a/importer/api/books.py
+++ b/importer/api/books.py
@@ -184,3 +184,66 @@ class BookMetadataAPI(JsonLoginRequiredMixin, View):
 
         book.save()
         return JsonResponse(serialize_book(book))
+
+
+class BookChaptersAPI(JsonLoginRequiredMixin, View):
+    def _chapter_file(self, book: Book) -> Path:
+        dest = Path(book.dest_path)
+        return dest.parent / (dest.stem + '.chapters.txt')
+
+    def get(self, request, pk):
+        try:
+            book = Book.objects.get(pk=pk)
+        except Book.DoesNotExist:
+            return JsonResponse({'error': 'Book not found'}, status=404)
+
+        chapter_file = self._chapter_file(book)
+        if not chapter_file.exists():
+            return JsonResponse({'error': 'Chapter file not found'}, status=404)
+
+        chapters = []
+        idx = 0
+        with open(chapter_file) as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped or stripped.startswith('#'):
+                    continue
+                parts = stripped.split(' ', 1)
+                if len(parts) == 2:
+                    idx += 1
+                    chapters.append({'index': idx, 'timestamp': parts[0], 'name': parts[1]})
+        return JsonResponse(chapters, safe=False)
+
+    def put(self, request, pk):
+        try:
+            book = Book.objects.get(pk=pk)
+        except Book.DoesNotExist:
+            return JsonResponse({'error': 'Book not found'}, status=404)
+
+        if not book.dest_path or not Path(book.dest_path).exists():
+            return JsonResponse({'error': 'Output file not found on disk'}, status=400)
+
+        mp4chaps = shutil.which('mp4chaps')
+        if not mp4chaps:
+            return JsonResponse({'error': 'mp4chaps not available'}, status=503)
+
+        try:
+            chapters = json.loads(request.body)
+        except json.JSONDecodeError:
+            return JsonResponse({'error': 'Invalid JSON body'}, status=400)
+
+        chapter_file = self._chapter_file(book)
+        with open(chapter_file, 'w') as f:
+            for ch in chapters:
+                f.write(f"{ch['timestamp']} {ch['name']}\n")
+
+        try:
+            result = subprocess.run([mp4chaps, '-i', book.dest_path], capture_output=True, timeout=60)
+            if result.returncode != 0:
+                return JsonResponse({'error': result.stderr.decode(errors='replace')}, status=500)
+        except subprocess.TimeoutExpired:
+            return JsonResponse({'error': 'mp4chaps timed out'}, status=500)
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)
+
+        return JsonResponse({'ok': True})

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -6,7 +6,7 @@ from .api.auth import (
     PasskeyLoginBeginAPI, PasskeyLoginCompleteAPI,
     PasskeyRegisterBeginAPI, PasskeyRegisterCompleteAPI,
 )
-from .api.books import BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI
+from .api.books import BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI
 from .api.config import SettingsAPI, SettingsVerifyAPI, VersionsAPI
 from .api.import_pipeline import AsinSearchAPI, DirectoryListAPI, ImportStartAPI, MatchAPI
 from .api.users import UserDetailAPI, UsersListAPI
@@ -33,6 +33,7 @@ api_patterns = [
     path('api/books/<int:pk>/', BookDetailAPI.as_view(), name='api-book-detail'),
     path('api/books/<int:pk>/reprocess/', BookReprocessAPI.as_view(), name='api-book-reprocess'),
     path('api/books/<int:pk>/metadata/', BookMetadataAPI.as_view(), name='api-book-metadata'),
+    path('api/books/<int:pk>/chapters/', BookChaptersAPI.as_view(), name='api-book-chapters'),
 
     # Import / match
     path('api/match/', MatchAPI.as_view(), name='api-match'),


### PR DESCRIPTION
## Summary
- `GET /api/books/<id>/chapters/` reads `{stem}.chapters.txt` and returns `[{index, timestamp, name}]`
- `PUT /api/books/<id>/chapters/` rewrites the chapter file and runs `mp4chaps -i` to embed chapters in the .m4b
- BookDetailPage shows an expandable Chapters card (DONE books only); chapter names are editable inline
- Returns 503 if `mp4chaps` binary is not available (present in Docker, may not be in local dev)

## Test plan
- [ ] On a DONE book with a chapters.txt, open Chapters — list loads
- [ ] Edit a chapter name, click Save — verify embedded chapters updated
- [ ] On a book without chapters.txt — shows 'No chapters found' (404 handled gracefully)

Closes #31