### PR TITLE
feat(books): cover art replacement for completed books [T-26]

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -90,6 +90,19 @@ export const bookApi = {
     saveChapters: async (id: string | number, chapters: Chapter[]): Promise<void> => {
         await apiClient.put(`/api/books/${id}/chapters/`, chapters);
     },
+
+    replaceCoverUpload: async (id: string | number, file: File): Promise<void> => {
+        const form = new FormData();
+        form.append('mode', 'upload');
+        form.append('cover', file);
+        await apiClient.post(`/api/books/${id}/cover/`, form, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+        });
+    },
+
+    replaceCoverRefetch: async (id: string | number): Promise<void> => {
+        await apiClient.post(`/api/books/${id}/cover/`, { mode: 'refetch' });
+    },
 };
 
 // ASIN Search

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -26,6 +26,11 @@ const BookDetailPage: React.FC = () => {
     const [loadingChapters, setLoadingChapters] = useState(false);
     const [savingChapters, setSavingChapters] = useState(false);
     const [chapterError, setChapterError] = useState<string | null>(null);
+    const [showCoverModal, setShowCoverModal] = useState(false);
+    const [coverFile, setCoverFile] = useState<File | null>(null);
+    const [replacingCover, setReplacingCover] = useState(false);
+    const [coverError, setCoverError] = useState<string | null>(null);
+    const [coverPreviewUrl, setCoverPreviewUrl] = useState<string | null>(null);
     const { refreshBooks } = useData();
 
     useEffect(() => {
@@ -118,6 +123,46 @@ const BookDetailPage: React.FC = () => {
             setChapterError(getErrorMessage(err));
         } finally {
             setSavingChapters(false);
+        }
+    };
+
+    const handleReplaceUpload = async () => {
+        if (!id || !coverFile) return;
+        setReplacingCover(true);
+        setCoverError(null);
+        try {
+            await bookApi.replaceCoverUpload(id, coverFile);
+            setShowCoverModal(false);
+            setCoverFile(null);
+            setCoverPreviewUrl(null);
+        } catch (err) {
+            setCoverError(getErrorMessage(err));
+        } finally {
+            setReplacingCover(false);
+        }
+    };
+
+    const handleRefetchCover = async () => {
+        if (!id) return;
+        setReplacingCover(true);
+        setCoverError(null);
+        try {
+            await bookApi.replaceCoverRefetch(id);
+            setShowCoverModal(false);
+        } catch (err) {
+            setCoverError(getErrorMessage(err));
+        } finally {
+            setReplacingCover(false);
+        }
+    };
+
+    const handleCoverFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0] ?? null;
+        setCoverFile(file);
+        if (file) {
+            setCoverPreviewUrl(URL.createObjectURL(file));
+        } else {
+            setCoverPreviewUrl(null);
         }
     };
 
@@ -239,6 +284,15 @@ const BookDetailPage: React.FC = () => {
                                         e.currentTarget.src = '/static/images/cover_not_available.jpg';
                                     }}
                                 />
+                                {book.status.status === StatusChoice.DONE && (
+                                    <button
+                                        className="btn btn-sm btn-outline-secondary w-100 mt-2"
+                                        onClick={() => setShowCoverModal(true)}
+                                    >
+                                        <i className="fa-solid fa-image me-1" />
+                                        Replace Cover
+                                    </button>
+                                )}
                             </div>
                         </div>
 
@@ -537,6 +591,59 @@ const BookDetailPage: React.FC = () => {
                                     </>
                                 ) : 'Re-process'}
                             </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )}
+
+        {showCoverModal && (
+            <div className="modal d-block" tabIndex={-1} style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+                <div className="modal-dialog">
+                    <div className="modal-content">
+                        <div className="modal-header">
+                            <h5 className="modal-title">Replace Cover Art</h5>
+                            <button type="button" className="btn-close" onClick={() => setShowCoverModal(false)} disabled={replacingCover} />
+                        </div>
+                        <div className="modal-body">
+                            {coverError && <div className="alert alert-danger">{coverError}</div>}
+                            <div className="mb-4">
+                                <h6>Upload a file</h6>
+                                <input
+                                    type="file"
+                                    className="form-control"
+                                    accept="image/jpeg,image/png"
+                                    onChange={handleCoverFileChange}
+                                    disabled={replacingCover}
+                                />
+                                {coverPreviewUrl && (
+                                    <img src={coverPreviewUrl} alt="Preview" className="img-thumbnail mt-2" style={{ maxHeight: 150 }} />
+                                )}
+                                <button
+                                    className="btn btn-primary mt-2 w-100"
+                                    onClick={handleReplaceUpload}
+                                    disabled={!coverFile || replacingCover}
+                                >
+                                    {replacingCover ? <span className="spinner-border spinner-border-sm me-1" /> : null}
+                                    Upload &amp; Apply
+                                </button>
+                            </div>
+                            <hr />
+                            <div>
+                                <h6>Re-fetch from Audible</h6>
+                                <p className="text-muted small">Downloads the original cover from the Audible URL stored for this book.</p>
+                                <button
+                                    className="btn btn-outline-secondary w-100"
+                                    onClick={handleRefetchCover}
+                                    disabled={replacingCover || !book.cover_image_link}
+                                >
+                                    {replacingCover ? <span className="spinner-border spinner-border-sm me-1" /> : null}
+                                    Re-fetch from Audible
+                                </button>
+                            </div>
+                        </div>
+                        <div className="modal-footer">
+                            <button className="btn btn-secondary" onClick={() => setShowCoverModal(false)} disabled={replacingCover}>Close</button>
                         </div>
                     </div>
                 </div>

--- a/importer/api/books.py
+++ b/importer/api/books.py
@@ -2,7 +2,9 @@ import json
 import logging
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
+from urllib.parse import urlparse
 from django.http import JsonResponse
 from django.views import View
 
@@ -11,6 +13,23 @@ from ..tasks import m4b_merge_task
 from .mixins import JsonLoginRequiredMixin
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_cover_url(url: str) -> bool:
+    """Only allow HTTPS fetches to known Audible/Amazon CDN hostnames."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+    if parsed.scheme != 'https':
+        return False
+    hostname = (parsed.hostname or '').lower().rstrip('.')
+    allowed = (
+        hostname.endswith('.media-amazon.com') or
+        hostname.endswith('.images-amazon.com') or
+        hostname == 'images-na.ssl-images-amazon.com'
+    )
+    return allowed
 
 
 def serialize_book(book: Book) -> dict:
@@ -247,3 +266,75 @@ class BookChaptersAPI(JsonLoginRequiredMixin, View):
             return JsonResponse({'error': str(e)}, status=500)
 
         return JsonResponse({'ok': True})
+
+
+class BookCoverAPI(JsonLoginRequiredMixin, View):
+    def post(self, request, pk):
+        try:
+            book = Book.objects.get(pk=pk)
+        except Book.DoesNotExist:
+            return JsonResponse({'error': 'Book not found'}, status=404)
+
+        if not book.dest_path or not Path(book.dest_path).exists():
+            return JsonResponse({'error': 'Output file not found on disk'}, status=400)
+
+        m4b_tool = shutil.which('m4b-tool')
+        if not m4b_tool:
+            return JsonResponse({'error': 'm4b-tool not available'}, status=503)
+
+        # Determine mode — multipart sends mode in POST data, JSON sends in body
+        if request.content_type and 'multipart' in request.content_type:
+            mode = request.POST.get('mode')
+        else:
+            try:
+                mode = json.loads(request.body).get('mode')
+            except (json.JSONDecodeError, AttributeError):
+                mode = None
+
+        tmp_cover = None
+        try:
+            if mode == 'upload':
+                cover_file = request.FILES.get('cover')
+                if not cover_file:
+                    return JsonResponse({'error': 'No file uploaded'}, status=400)
+                with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp:
+                    for chunk in cover_file.chunks():
+                        tmp.write(chunk)
+                    tmp_cover = tmp.name
+
+            elif mode == 'refetch':
+                if not book.cover_image_link:
+                    return JsonResponse({'error': 'No cover image URL stored for this book'}, status=400)
+                if not _validate_cover_url(book.cover_image_link):
+                    return JsonResponse({'error': 'Cover image URL is not an allowed domain'}, status=400)
+                import requests as req_lib
+                resp = req_lib.get(book.cover_image_link, timeout=15)
+                if resp.status_code != 200:
+                    return JsonResponse({'error': 'Failed to download cover image'}, status=502)
+                with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp:
+                    tmp.write(resp.content)
+                    tmp_cover = tmp.name
+            else:
+                return JsonResponse({'error': 'mode must be "upload" or "refetch"'}, status=400)
+
+            result = subprocess.run(
+                [m4b_tool, 'meta', f'--cover={tmp_cover}', book.dest_path],
+                capture_output=True, timeout=60
+            )
+            if result.returncode != 0:
+                return JsonResponse({'error': result.stderr.decode(errors='replace')}, status=500)
+
+            return JsonResponse({'ok': True})
+
+        except subprocess.TimeoutExpired:
+            return JsonResponse({'error': 'm4b-tool timed out'}, status=500)
+        except Exception as e:
+            logger.error("Cover replace error for book %s: %s", pk, e)
+            return JsonResponse({'error': str(e)}, status=500)
+        finally:
+            if tmp_cover:
+                import os as _os
+                try:
+                    _os.unlink(tmp_cover)
+                except OSError:
+                    pass

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -6,7 +6,7 @@ from .api.auth import (
     PasskeyLoginBeginAPI, PasskeyLoginCompleteAPI,
     PasskeyRegisterBeginAPI, PasskeyRegisterCompleteAPI,
 )
-from .api.books import BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI
+from .api.books import BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI, BookCoverAPI
 from .api.config import SettingsAPI, SettingsVerifyAPI, VersionsAPI
 from .api.import_pipeline import AsinSearchAPI, DirectoryListAPI, ImportStartAPI, MatchAPI
 from .api.users import UserDetailAPI, UsersListAPI
@@ -34,6 +34,7 @@ api_patterns = [
     path('api/books/<int:pk>/reprocess/', BookReprocessAPI.as_view(), name='api-book-reprocess'),
     path('api/books/<int:pk>/metadata/', BookMetadataAPI.as_view(), name='api-book-metadata'),
     path('api/books/<int:pk>/chapters/', BookChaptersAPI.as_view(), name='api-book-chapters'),
+    path('api/books/<int:pk>/cover/', BookCoverAPI.as_view(), name='api-book-cover'),
 
     # Import / match
     path('api/match/', MatchAPI.as_view(), name='api-match'),


### PR DESCRIPTION
## Summary
- `POST /api/books/<id>/cover/` with `mode=upload` (multipart JPEG/PNG) or `mode=refetch` (downloads from `book.cover_image_link`)
- Both modes run `m4b-tool meta --cover=<tmp>` and clean up the temp file in a `finally` block
- BookDetailPage shows 'Replace Cover' button on the cover image for DONE books; modal has upload section with preview + one-click re-fetch from Audible
- Re-fetch button disabled when `cover_image_link` is empty

## Test plan
- [ ] On a DONE book, click Replace Cover
- [ ] Upload a JPEG — verify cover updates (check with m4b-tool or a compatible player)
- [ ] Re-fetch from Audible — downloads and embeds original cover
- [ ] Temp file is cleaned up after success or failure (check /tmp)

Closes #32