### PR TITLE
feat(books): add Recently Added sort option

### DIFF
--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -5,7 +5,7 @@ import LibraryBookCard from '../components/LibraryBookCard';
 import Pagination from '../components/Pagination';
 import { useData } from '../context/DataContext';
 
-type SortOption = 'title' | 'release_date' | 'author';
+type SortOption = 'title' | 'release_date' | 'author' | 'recently_added';
 
 const BooksPage: React.FC = () => {
     const location = useLocation();
@@ -58,6 +58,8 @@ const BooksPage: React.FC = () => {
                     const authorA = a.authors[0] ? `${a.authors[0].last_name} ${a.authors[0].first_name}` : '';
                     const authorB = b.authors[0] ? `${b.authors[0].last_name} ${b.authors[0].first_name}` : '';
                     return authorA.localeCompare(authorB);
+                case 'recently_added':
+                    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
                 default:
                     return 0;
             }
@@ -150,6 +152,7 @@ const BooksPage: React.FC = () => {
                             <option value="title">Alphabetical</option>
                             <option value="release_date">Release Date</option>
                             <option value="author">Author</option>
+                            <option value="recently_added">Recently Added</option>
                         </select>
                     </div>
 


### PR DESCRIPTION
## Summary

- Adds `'recently_added'` to `SortOption` type
- Sorts by `created_at` descending (newest imports first) — `created_at` is already in the serialized book response, no backend changes needed
- Adds "Recently Added" option to the sort dropdown after "Author"

## Test plan
- [ ] Sort dropdown includes "Recently Added"
- [ ] Selecting it shows most recently imported books first
- [ ] Other sort options (Alphabetical, Release Date, Author) unaffected

Closes #60