### PR TITLE
feat(auth): show friendly message when no passkey is registered

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -38,7 +38,15 @@ const LoginPage: React.FC = () => {
             await checkAuth();
             navigate('/');
         } catch (err) {
-            setError(getErrorMessage(err));
+            const isDomNotAllowed = err instanceof DOMException && err.name === 'NotAllowedError';
+            const isUnknownCred = getErrorMessage(err).toLowerCase().includes('unknown credential');
+            if (isDomNotAllowed || isUnknownCred) {
+                setError(
+                    'No passkey found. Sign in with your username and password, then go to Settings → Security to register a passkey.'
+                );
+            } else {
+                setError(getErrorMessage(err));
+            }
         } finally {
             setPasskeyLoading(false);
         }


### PR DESCRIPTION
## Summary

When a user clicks "Sign in with a passkey" without a passkey registered, they previously saw a raw browser error (`NotAllowedError`) or the backend's `Unknown credential` string. Both are confusing.

Now detects two failure cases in `handlePasskeyLogin`:
- `DOMException { name: 'NotAllowedError' }` — browser cancelled or no credential on device
- Error message containing `'unknown credential'` (backend 401) — credential ID not in DB

Both show: _"No passkey found. Sign in with your username and password, then go to Settings → Security to register a passkey."_

All other errors still show the raw message.

## Test plan
- [ ] Click "Sign in with a passkey" with no passkey registered → friendly guidance message appears
- [ ] Cancel the browser passkey prompt → same friendly message
- [ ] Network errors during passkey flow still show the raw error

Closes #61