### PR TITLE
feat(import): Step 1 selection panel + green Next button

### DIFF
--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -131,7 +131,7 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
                     </button>
                 </div>
             </div>
-            <div className="list-group list-group-flush" style={{ height: 'calc(100vh - 450px)', overflowY: 'auto' }}>
+            <div className="list-group list-group-flush" style={{ maxHeight: 'calc(100vh - 350px)', overflowY: 'auto' }}>
                 {rootItems.length === 0 ? (
                     <div className="list-group-item text-center text-muted">No files or directories found</div>
                 ) : (

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -43,10 +43,6 @@ const ImportPage: React.FC = () => {
     }, []);
 
     const handleNext = useCallback(async () => {
-        if (selectedPaths.length === 0) {
-            setError('Select at least one directory to import');
-            return;
-        }
         setError(null);
 
         const initial: AsinCard[] = selectedPaths.map(p => ({
@@ -146,35 +142,65 @@ const ImportPage: React.FC = () => {
                 <div className="col">
                     <div className="card">
                         <div className="card-header">
-                            <h5 className="mb-0">Step 1 — Choose Files or Directories to process</h5>
+                            <h5 className="mb-0">Step 1 — Choose Files or Directories to Import</h5>
                         </div>
                         <div className="card-body p-0">
                             {error && (
-                                <div className="alert alert-danger m-3" role="alert">{error}</div>
+                                <div className="alert alert-danger m-3 mb-0" role="alert">{error}</div>
                             )}
-                            {loadingFiles ? (
-                                <div className="text-center p-4">
-                                    <div className="spinner-border" role="status">
-                                        <span className="visually-hidden">Loading...</span>
-                                    </div>
+                            <div className="d-flex" style={{ minHeight: 400 }}>
+                                {/* File Explorer */}
+                                <div className="flex-grow-1 border-end" style={{ minWidth: 0 }}>
+                                    {loadingFiles ? (
+                                        <div className="text-center p-4">
+                                            <div className="spinner-border" role="status">
+                                                <span className="visually-hidden">Loading...</span>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <FileExplorer
+                                            rootItems={contents}
+                                            selectedPaths={selectedPaths}
+                                            onSelectionChange={setSelectedPaths}
+                                            fetchChildren={fetchChildren}
+                                        />
+                                    )}
                                 </div>
-                            ) : (
-                                <FileExplorer
-                                    rootItems={contents}
-                                    selectedPaths={selectedPaths}
-                                    onSelectionChange={setSelectedPaths}
-                                    fetchChildren={fetchChildren}
-                                />
-                            )}
-                            <div className="p-3">
-                                <button
-                                    className="btn btn-primary w-100"
-                                    onClick={handleNext}
-                                    disabled={loadingFiles}
-                                >
-                                    Next
-                                </button>
+                                {/* Selection Panel */}
+                                <div className="import-selection-panel p-3" style={{ width: 260, flexShrink: 0 }}>
+                                    <div className="fw-semibold mb-2 small text-uppercase text-muted">
+                                        Selected ({selectedPaths.length})
+                                    </div>
+                                    {selectedPaths.length === 0 ? (
+                                        <p className="text-muted small">Nothing selected yet. Check items on the left to add them.</p>
+                                    ) : (
+                                        <ul className="list-unstyled mb-0">
+                                            {selectedPaths.map(p => (
+                                                <li key={p} className="d-flex align-items-start justify-content-between gap-1 mb-2">
+                                                    <span className="small text-break">{p.split('/').pop() || p}</span>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-link btn-sm p-0 flex-shrink-0 text-danger"
+                                                        onClick={() => setSelectedPaths(prev => prev.filter(x => x !== p))}
+                                                        title="Remove"
+                                                    >
+                                                        <i className="fas fa-times" />
+                                                    </button>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </div>
                             </div>
+                        </div>
+                        <div className="card-footer p-3">
+                            <button
+                                className="btn btn-success w-100"
+                                onClick={handleNext}
+                                disabled={loadingFiles || selectedPaths.length === 0}
+                            >
+                                Next →
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -612,6 +612,13 @@ $btn-primary-hover-border: color.adjust($bragi-red, $lightness: -10%);
 }
 
 
+// Import page selection panel
+.import-selection-panel {
+    background-color: rgba(0, 0, 0, 0.02);
+    overflow-y: auto;
+    max-height: calc(100vh - 300px);
+}
+
 // Dark mode theme styles
 [data-theme="dark"] {
     // Base colors
@@ -904,6 +911,11 @@ $btn-primary-hover-border: color.adjust($bragi-red, $lightness: -10%);
                 }
             }
         }
+    }
+
+    // Import page selection panel (dark mode)
+    .import-selection-panel {
+        background-color: rgba(255, 255, 255, 0.03);
     }
 
     // Pagination (dark mode)


### PR DESCRIPTION
## Summary

- Adds a right-hand selection panel (~260px) alongside the file explorer in Import Step 1, showing selected paths with individual × remove buttons and a "Nothing selected yet" placeholder when empty
- Moves the Next button to `card-footer` and changes it to `btn-success` (green) to match the app's colour theme
- Next button is disabled until at least one path is selected — removes the need for the "select at least one" error message
- Adjusts `FileExplorer` list container from fixed `height` to `maxHeight` to avoid double scroll bars in the new layout
- Adds `.import-selection-panel` SCSS for light and dark mode

## Test plan
- [ ] Step 1 shows two-column layout: file tree on left, selected paths panel on right
- [ ] Selecting a file/folder adds it to the right panel
- [ ] Clicking × in the panel deselects the item (unchecks it in the file tree too)
- [ ] Next → button is green and disabled until at least one item is checked
- [ ] In dark mode, the selection panel has the correct subtle background

Closes #62