### PR TITLE
feat(import): Step 2 Match Audiobook redesign — dropdown + type fix

### DIFF
--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -221,7 +221,7 @@ const ImportPage: React.FC = () => {
                             >
                                 &larr; Back
                             </button>
-                            <h5 className="mb-0">Step 2 — Match ASINs</h5>
+                            <h5 className="mb-0">Step 2 — Match Audiobook</h5>
                         </div>
                         <div className="card-body">
                             {error && (
@@ -229,72 +229,58 @@ const ImportPage: React.FC = () => {
                             )}
                             {cards.map((card, index) => (
                                 <div key={card.srcPath} className="row mb-4 pb-4 border-bottom">
-                                    <div className="col-md-3 text-center">
+                                    <div className="col-auto text-center">
                                         <img
                                             src={card.imageUrl}
                                             alt={card.srcPath.split('/').pop()}
-                                            className="img-fluid mb-2"
-                                            style={{ width: 150, borderRadius: 10, objectFit: 'cover' }}
+                                            style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 8 }}
                                             onError={e => { e.currentTarget.src = FALLBACK_IMAGE; }}
                                         />
+                                    </div>
+                                    <div className="col d-flex flex-column justify-content-center gap-2">
                                         <div className="fw-bold text-break small">
                                             {card.srcPath.split('/').pop()}
                                         </div>
-                                    </div>
-                                    <div className="col-md-9 d-flex flex-column justify-content-center gap-2">
                                         {card.searching ? (
                                             <div className="d-flex align-items-center gap-2">
                                                 <div className="spinner-border spinner-border-sm" role="status" />
-                                                <span className="text-muted">Searching Audible…</span>
-                                            </div>
-                                        ) : card.options.length > 0 ? (
-                                            <div>
-                                                <label className="form-label fw-semibold">Select a match</label>
-                                                {card.options.map(opt => (
-                                                    <div key={opt.asin} className="mb-2 d-flex align-items-center gap-2">
-                                                        <input
-                                                            className="form-check-input flex-shrink-0"
-                                                            type="radio"
-                                                            name={`asin-${index}`}
-                                                            id={`asin-${index}-${opt.asin}`}
-                                                            value={opt.asin}
-                                                            checked={card.selectedAsin === opt.asin}
-                                                            onChange={() => handleAsinSelect(index, opt.asin)}
-                                                        />
-                                                        <img
-                                                            src={opt.image_link?.[0] ?? FALLBACK_IMAGE}
-                                                            alt=""
-                                                            style={{ width: 60, height: 60, objectFit: 'cover', borderRadius: 4, flexShrink: 0 }}
-                                                            onError={e => { e.currentTarget.src = FALLBACK_IMAGE; }}
-                                                        />
-                                                        <label
-                                                            className="form-check-label text-truncate"
-                                                            htmlFor={`asin-${index}-${opt.asin}`}
-                                                            title={`${opt.title} — ${opt.authors}`}
-                                                        >
-                                                            <div className="fw-semibold">{opt.title}</div>
-                                                            <div className="text-muted small">{opt.authors} <span className="ms-1">({opt.asin})</span></div>
-                                                        </label>
-                                                    </div>
-                                                ))}
+                                                <span className="text-muted small">Searching Audible…</span>
                                             </div>
                                         ) : (
-                                            <div className="text-muted small">No Audible results found.</div>
+                                            <div>
+                                                <label className="form-label fw-semibold mb-1">Match</label>
+                                                <select
+                                                    className="form-select form-select-sm"
+                                                    value={card.selectedAsin}
+                                                    onChange={e => handleAsinSelect(index, e.target.value)}
+                                                >
+                                                    {card.options.length === 0 && (
+                                                        <option value="" disabled>No results found</option>
+                                                    )}
+                                                    {card.options.map(opt => (
+                                                        <option key={opt.asin} value={opt.asin}>
+                                                            {opt.title} — {opt.author}{opt.narrator ? ` / ${opt.narrator}` : ''} ({opt.asin})
+                                                        </option>
+                                                    ))}
+                                                    <option value="">Enter manually…</option>
+                                                </select>
+                                            </div>
                                         )}
-                                        <div>
-                                            <label className="form-label fw-semibold mb-1">
-                                                Manual ASIN
-                                                <span className="text-muted fw-normal ms-1">(overrides selection)</span>
-                                            </label>
-                                            <input
-                                                className="form-control form-control-sm"
-                                                type="text"
-                                                placeholder="e.g. B001234567"
-                                                maxLength={10}
-                                                value={card.manualAsin}
-                                                onChange={e => handleManualAsinChange(index, e.target.value)}
-                                            />
-                                        </div>
+                                        {(card.selectedAsin === '' || card.options.length === 0) && (
+                                            <div>
+                                                <label className="form-label small mb-1">
+                                                    ASIN <span className="text-muted">(10 characters)</span>
+                                                </label>
+                                                <input
+                                                    className="form-control form-control-sm"
+                                                    type="text"
+                                                    placeholder="e.g. B001234567"
+                                                    maxLength={10}
+                                                    value={card.manualAsin}
+                                                    onChange={e => handleManualAsinChange(index, e.target.value)}
+                                                />
+                                            </div>
+                                        )}
                                         <button
                                             type="button"
                                             className="btn btn-sm btn-outline-danger align-self-start"
@@ -313,11 +299,11 @@ const ImportPage: React.FC = () => {
                         </div>
                         <div className="card-footer">
                             <button
-                                className="btn btn-primary w-100"
+                                className="btn btn-success w-100"
                                 type="submit"
                                 disabled={!canSubmit || submitting}
                             >
-                                {submitting ? 'Submitting…' : 'Submit ASINs'}
+                                {submitting ? 'Submitting…' : 'Submit'}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -90,12 +90,8 @@ export interface DirectoryContents {
 export interface AsinSearchResult {
     asin: string;
     title: string;
-    subtitle?: string;
-    authors: string;
-    narrators: string;
-    publisher: string;
-    release_date: string;
-    runtime_length_min: number;
+    author: string;
+    narrator: string;
     image_link?: string[];
     score: number;
 }


### PR DESCRIPTION
## Summary

- Renames "Step 2 — Match ASINs" → "Step 2 — Match Audiobook"
- Replaces the radio-button list with a compact `<select>` dropdown; each option shows `title — author / narrator (asin)`
- "Enter manually…" option at the bottom of the dropdown reveals a text input for a manual ASIN; the input also auto-appears when no search results were found
- Submit button changed to `btn-success` (green) to match Step 1
- **Fixes a silent type bug:** `AsinSearchResult` was declaring `authors: string` and `narrators: string` but the backend returns `author` and `narrator` (singular). The UI was rendering `undefined` for the author field. Types now match the actual API response; removed unused fields (`subtitle`, `publisher`, `release_date`, `runtime_length_min`) that were never returned.

## Test plan
- [ ] Step 2 header reads "Step 2 — Match Audiobook"
- [ ] Dropdown shows results as "Title — Author / Narrator (ASIN)"
- [ ] Selecting "Enter manually…" shows ASIN text input below
- [ ] When no Audible results found, ASIN input appears automatically
- [ ] Cover thumbnail updates when a different option is selected
- [ ] Submit button is green; disabled until all cards have a valid ASIN

Closes #63