### PR TITLE
feat(processing): 1s live poll, progress bar, elapsed time, expandable error logs

### DIFF
--- a/frontend/src/pages/ProcessingPage.tsx
+++ b/frontend/src/pages/ProcessingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import { useData } from '../context/DataContext';
@@ -9,6 +9,14 @@ const ProcessingPage: React.FC = () => {
     const [reprocessingId, setReprocessingId] = useState<number | null>(null);
     const [reprocessAsin, setReprocessAsin] = useState('');
     const [reprocessError, setReprocessError] = useState<string | null>(null);
+    const [expandedLogs, setExpandedLogs] = useState<Set<number>>(new Set());
+
+    // 1-second poll while this page is open and books are processing
+    useEffect(() => {
+        if (books.processing.length === 0) return;
+        const id = setInterval(refreshBooks, 1_000);
+        return () => clearInterval(id);
+    }, [books.processing.length, refreshBooks]);
 
     const handleReprocess = async (bookId: number, asin?: string) => {
         try {
@@ -39,21 +47,40 @@ const ProcessingPage: React.FC = () => {
                     <p className="text-muted">Nothing processing right now.</p>
                 ) : (
                     <div className="list-group">
-                        {books.processing.map(book => (
-                            <div key={book.id} className="list-group-item d-flex align-items-center gap-3">
-                                <div className="spinner-border spinner-border-sm text-primary flex-shrink-0" role="status">
-                                    <span className="visually-hidden">Processing…</span>
-                                </div>
-                                <div className="flex-grow-1">
-                                    <strong>{book.title}</strong>
-                                    {book.authors[0] && (
-                                        <span className="text-muted ms-2">
-                                            {book.authors[0].first_name} {book.authors[0].last_name}
-                                        </span>
+                        {books.processing.map(book => {
+                            const elapsed = Math.floor((Date.now() - new Date(book.updated_at).getTime()) / 1000);
+                            const elapsedStr = elapsed < 60
+                                ? `${elapsed}s`
+                                : `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`;
+                            return (
+                                <div key={book.id} className="list-group-item">
+                                    <div className="d-flex align-items-center gap-3 mb-2">
+                                        <div className="flex-grow-1">
+                                            <div className="fw-bold">{book.title}</div>
+                                            {book.authors[0] && (
+                                                <div className="text-muted small">
+                                                    {book.authors[0].first_name} {book.authors[0].last_name}
+                                                </div>
+                                            )}
+                                        </div>
+                                        <span className="text-muted small flex-shrink-0">{elapsedStr}</span>
+                                    </div>
+                                    <div className="progress mb-1" style={{ height: 6 }}>
+                                        <div
+                                            className="progress-bar progress-bar-striped progress-bar-animated"
+                                            role="progressbar"
+                                            style={{ width: '100%' }}
+                                        />
+                                    </div>
+                                    {book.status.message && (
+                                        <div className="text-muted small mt-1">
+                                            <i className="fas fa-circle-info me-1" />
+                                            {book.status.message}
+                                        </div>
                                     )}
                                 </div>
-                            </div>
-                        ))}
+                            );
+                        })}
                     </div>
                 )}
             </section>
@@ -76,7 +103,28 @@ const ProcessingPage: React.FC = () => {
                                             </span>
                                         )}
                                         {book.status.message && (
-                                            <p className="text-danger small mb-1 mt-1">{book.status.message}</p>
+                                            <>
+                                                <div
+                                                    className="text-danger small mt-1 d-flex align-items-center gap-1"
+                                                    style={{ cursor: 'pointer' }}
+                                                    onClick={() => setExpandedLogs(prev => {
+                                                        const next = new Set(prev);
+                                                        next.has(book.id) ? next.delete(book.id) : next.add(book.id);
+                                                        return next;
+                                                    })}
+                                                >
+                                                    <i className={`fas fa-angle-${expandedLogs.has(book.id) ? 'up' : 'down'}`} />
+                                                    {expandedLogs.has(book.id) ? 'Hide logs' : 'Show logs'}
+                                                </div>
+                                                {expandedLogs.has(book.id) && (
+                                                    <pre
+                                                        className="text-danger small bg-danger bg-opacity-10 rounded p-2 mt-1"
+                                                        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: 300, overflowY: 'auto', fontSize: '0.75rem' }}
+                                                    >
+                                                        {book.status.message}
+                                                    </pre>
+                                                )}
+                                            </>
                                         )}
                                         {reprocessError && reprocessingId === book.id && (
                                             <p className="text-danger small mb-0">{reprocessError}</p>
@@ -93,7 +141,6 @@ const ProcessingPage: React.FC = () => {
                                             />
                                             <button
                                                 className="btn btn-sm btn-outline-primary"
-                                                disabled={reprocessingId === book.id && reprocessAsin === '' && false}
                                                 onClick={() => handleReprocess(book.id, reprocessAsin || undefined)}
                                             >
                                                 {reprocessingId === book.id ? (

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -78,6 +78,11 @@ class BragiM4bMerge(m4b_helper.M4bMerge):
             logger.warning("Could not reformat chapter names: %s", chapter_file)
 
 
+def _update_status_message(book, message):
+    book.status.message = message
+    book.status.save(update_fields=['message'])
+
+
 def set_configs():
     existing_settings = Setting.load()
     if existing_settings:
@@ -109,6 +114,7 @@ def run_m4b_merge(asin: str):
     setting = Setting.load()
     logger.info(
         f"{'-' * 15} Starting to process {asin}: {book.title} {'-' * 15}")
+    _update_status_message(book, "Preparing: reading input files…")
 
     input_data = helpers.get_directory(Path(book.src_path))
     if not input_data:
@@ -122,8 +128,10 @@ def run_m4b_merge(asin: str):
     audible = audible_helper.BookData(asin)
 
     try:
+        _update_status_message(book, "Fetching metadata from Audible…")
         metadata = audible.fetch_api_data(config.api_url)
 
+        _update_status_message(book, "Loading chapters…")
         chapters = audible.get_chapters()
         if setting and setting.chapter_source == 'source_file':
             chapters = None
@@ -136,13 +144,14 @@ def run_m4b_merge(asin: str):
             setting=setting,
         )
 
+        _update_status_message(book, "Merging audio files (this may take a while)…")
         logger.info(f"Processing {book.title}")
         m4b.run_merge()
     except Exception as e:
         logger.error(f"Error occured while merging '{input_data}: {e}'")
         book.status.status = StatusChoices.ERROR
         message = str(e) + "\n" + \
-            traceback.format_exc() if settings.DEBUG else e
+            traceback.format_exc() if settings.DEBUG else str(e)
         book.status.message = message
         book.status.save()
         return
@@ -154,6 +163,7 @@ def run_m4b_merge(asin: str):
         f"{book.title}.m4b"
     )
     book.status.status = StatusChoices.DONE
+    book.status.message = ""
     book.status.save()
     logger.info(f"{'-' * 15} Done processing {asin} {'-' * 15}")
 


### PR DESCRIPTION
## Summary

**Backend (`utils/merge.py`):**
- Adds `_update_status_message()` helper (targeted `update_fields=['message']` write)
- Writes 4 milestone messages during processing: "Preparing…", "Fetching metadata…", "Loading chapters…", "Merging audio files…"
- Clears `status.message` on successful completion
- Fixes bare `e` in the except else-branch (should be `str(e)`)

**Frontend (`ProcessingPage.tsx`):**
- Adds a 1-second `setInterval` polling `refreshBooks` while the page is mounted and books are processing; clears on unmount or when queue drains (DataContext's 10s global poll remains as fallback)
- Processing items now show: animated striped Bootstrap progress bar, elapsed time since `updated_at`, current milestone message below the bar
- Error items now have a "Show logs / Hide logs" toggle that expands the full `status.message` (including tracebacks in DEBUG mode) in a scrollable `<pre>` block

## Test plan
- [ ] With a book processing, the ProcessingPage updates every ~1s showing the current milestone (e.g. "Fetching metadata from Audible…")
- [ ] Progress bar animates while processing
- [ ] Elapsed time counts up (resets at each milestone write since `updated_at` changes)
- [ ] Error books show "Show logs" — clicking expands the full error/traceback
- [ ] Poll interval stops when processing queue drains; no interval leak on navigating away

Closes #64