### PR TITLE
feat(processing): expandable job cards, cancel button, milestone log

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@types/dompurify": "^3.0.5",
         "axios": "^1.7.9",
         "bootstrap": "^5.3.8",
+        "dompurify": "^3.4.10",
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.0",
@@ -1320,6 +1322,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1384,6 +1395,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/warning": {
       "version": "3.0.4",
@@ -2008,6 +2025,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/dompurify": "^3.0.5",
     "axios": "^1.7.9",
     "bootstrap": "^5.3.8",
+    "dompurify": "^3.4.10",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -103,6 +103,10 @@ export const bookApi = {
     replaceCoverRefetch: async (id: string | number): Promise<void> => {
         await apiClient.post(`/api/books/${id}/cover/`, { mode: 'refetch' });
     },
+
+    cancel: async (id: string | number): Promise<void> => {
+        await apiClient.post(`/api/books/${id}/cancel/`);
+    },
 };
 
 // ASIN Search

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
@@ -6,6 +6,31 @@ import type { Author, Book, Chapter, Narrator } from '../types';
 import { StatusChoice } from '../types';
 import { bookApi, getErrorMessage } from '../api/services';
 import { useData } from '../context/DataContext';
+
+function parseChapterFile(text: string, filename: string): Chapter[] {
+    const lines = text.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+    const isCsv = filename.toLowerCase().endsWith('.csv');
+    const results: Chapter[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (isCsv) {
+            if (i === 0 && /^(timestamp|time|index)/i.test(line)) continue;
+            const commaIdx = line.indexOf(',');
+            if (commaIdx === -1) throw new Error(`Invalid CSV on line ${i + 1}: "${line}"`);
+            const timestamp = line.slice(0, commaIdx).trim().replace(/^"|"$/g, '');
+            const name = line.slice(commaIdx + 1).trim().replace(/^"|"$/g, '');
+            results.push({ index: results.length + 1, timestamp, name });
+        } else {
+            const spaceIdx = line.indexOf(' ');
+            if (spaceIdx === -1) throw new Error(`Invalid chapter line ${i + 1}: "${line}"`);
+            results.push({ index: results.length + 1, timestamp: line.slice(0, spaceIdx), name: line.slice(spaceIdx + 1).trim() });
+        }
+    }
+
+    if (results.length === 0) throw new Error('No chapters found in file');
+    return results;
+}
 
 const BookDetailPage: React.FC = () => {
     const { id } = useParams<{ id: string }>();
@@ -27,6 +52,8 @@ const BookDetailPage: React.FC = () => {
     const [loadingChapters, setLoadingChapters] = useState(false);
     const [savingChapters, setSavingChapters] = useState(false);
     const [chapterError, setChapterError] = useState<string | null>(null);
+    const [importError, setImportError] = useState<string | null>(null);
+    const chapterFileInputRef = useRef<HTMLInputElement>(null);
     const [showCoverModal, setShowCoverModal] = useState(false);
     const [coverFile, setCoverFile] = useState<File | null>(null);
     const [replacingCover, setReplacingCover] = useState(false);
@@ -125,6 +152,25 @@ const BookDetailPage: React.FC = () => {
         } finally {
             setSavingChapters(false);
         }
+    };
+
+    const handleImportChapters = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        e.target.value = '';
+        const reader = new FileReader();
+        reader.onload = (evt) => {
+            try {
+                const parsed = parseChapterFile(evt.target?.result as string, file.name);
+                setChapters(parsed);
+                setImportError(null);
+                setChapterError(null);
+                setChaptersOpen(true);
+            } catch (err) {
+                setImportError(getErrorMessage(err));
+            }
+        };
+        reader.readAsText(file);
     };
 
     const handleReplaceUpload = async () => {
@@ -440,54 +486,86 @@ const BookDetailPage: React.FC = () => {
                                         {chaptersOpen && (
                                             <div className="card-body">
                                                 {chapterError && (
-                                                    <div className="alert alert-danger">{chapterError}</div>
+                                                    <div className="alert alert-danger py-2">{chapterError}</div>
+                                                )}
+                                                {importError && (
+                                                    <div className="alert alert-danger py-2">{importError}</div>
                                                 )}
                                                 {loadingChapters ? (
                                                     <div className="text-center py-3"><div className="spinner-border" /></div>
                                                 ) : chapters.length === 0 ? (
-                                                    <p className="text-muted">No chapters found.</p>
+                                                    <p className="text-muted mb-3">No chapters found. Import a file to add them.</p>
                                                 ) : (
-                                                    <>
-                                                        <div className="table-responsive">
-                                                            <table className="table table-sm">
-                                                                <thead>
-                                                                    <tr>
-                                                                        <th style={{ width: 50 }}>#</th>
-                                                                        <th style={{ width: 130 }}>Timestamp</th>
-                                                                        <th>Name</th>
+                                                    <div className="table-responsive mb-3">
+                                                        <table className="table table-sm">
+                                                            <thead>
+                                                                <tr>
+                                                                    <th style={{ width: 40 }}>#</th>
+                                                                    <th style={{ width: 155 }}>Timestamp</th>
+                                                                    <th>Name</th>
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                                {chapters.map((ch, i) => (
+                                                                    <tr key={i}>
+                                                                        <td className="text-muted align-middle">{ch.index}</td>
+                                                                        <td>
+                                                                            <input
+                                                                                type="text"
+                                                                                className="form-control form-control-sm font-monospace"
+                                                                                value={ch.timestamp}
+                                                                                onChange={e => setChapters(prev => {
+                                                                                    const next = [...prev];
+                                                                                    next[i] = { ...next[i], timestamp: e.target.value };
+                                                                                    return next;
+                                                                                })}
+                                                                            />
+                                                                        </td>
+                                                                        <td>
+                                                                            <input
+                                                                                type="text"
+                                                                                className="form-control form-control-sm"
+                                                                                value={ch.name}
+                                                                                onChange={e => setChapters(prev => {
+                                                                                    const next = [...prev];
+                                                                                    next[i] = { ...next[i], name: e.target.value };
+                                                                                    return next;
+                                                                                })}
+                                                                            />
+                                                                        </td>
                                                                     </tr>
-                                                                </thead>
-                                                                <tbody>
-                                                                    {chapters.map((ch, i) => (
-                                                                        <tr key={i}>
-                                                                            <td className="text-muted">{ch.index}</td>
-                                                                            <td><code className="small">{ch.timestamp}</code></td>
-                                                                            <td>
-                                                                                <input
-                                                                                    type="text"
-                                                                                    className="form-control form-control-sm"
-                                                                                    value={ch.name}
-                                                                                    onChange={e => setChapters(prev => {
-                                                                                        const next = [...prev];
-                                                                                        next[i] = { ...next[i], name: e.target.value };
-                                                                                        return next;
-                                                                                    })}
-                                                                                />
-                                                                            </td>
-                                                                        </tr>
-                                                                    ))}
-                                                                </tbody>
-                                                            </table>
-                                                        </div>
+                                                                ))}
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
+                                                )}
+                                                {!loadingChapters && (
+                                                    <div className="d-flex gap-2 flex-wrap">
+                                                        {chapters.length > 0 && (
+                                                            <button
+                                                                className="btn btn-primary btn-sm"
+                                                                onClick={handleSaveChapters}
+                                                                disabled={savingChapters}
+                                                            >
+                                                                {savingChapters ? <span className="spinner-border spinner-border-sm me-1" role="status" /> : null}
+                                                                Save Chapters
+                                                            </button>
+                                                        )}
                                                         <button
-                                                            className="btn btn-primary btn-sm"
-                                                            onClick={handleSaveChapters}
-                                                            disabled={savingChapters}
+                                                            className="btn btn-outline-secondary btn-sm"
+                                                            onClick={() => chapterFileInputRef.current?.click()}
                                                         >
-                                                            {savingChapters ? <span className="spinner-border spinner-border-sm me-1" role="status" /> : null}
-                                                            Save Chapters
+                                                            <i className="fas fa-file-import me-1" />
+                                                            Import .txt / .csv
                                                         </button>
-                                                    </>
+                                                        <input
+                                                            ref={chapterFileInputRef}
+                                                            type="file"
+                                                            accept=".txt,.csv"
+                                                            className="d-none"
+                                                            onChange={handleImportChapters}
+                                                        />
+                                                    </div>
                                                 )}
                                             </div>
                                         )}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import type { Author, Book, Chapter, Narrator } from '../types';
@@ -326,9 +327,10 @@ const BookDetailPage: React.FC = () => {
                                 <div className="card mb-4">
                                     <div className="card-body">
                                         <h5 className="card-title">Description</h5>
-                                        <p className="card-text" style={{ whiteSpace: 'pre-wrap' }}>
-                                            {book.long_desc || book.short_desc}
-                                        </p>
+                                        <div
+                                            className="card-text"
+                                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(book.long_desc || book.short_desc) }}
+                                        />
                                     </div>
                                 </div>
                             )}

--- a/frontend/src/pages/ProcessingPage.tsx
+++ b/frontend/src/pages/ProcessingPage.tsx
@@ -13,6 +13,7 @@ const ProcessingPage: React.FC = () => {
     const [confirmCancelId, setConfirmCancelId] = useState<number | null>(null);
     const [cancellingId, setCancellingId] = useState<number | null>(null);
     const [expandedProcessing, setExpandedProcessing] = useState<Set<number>>(new Set());
+    const [expandedCompleted, setExpandedCompleted] = useState<Set<number>>(new Set());
 
     // 1-second poll while this page is open and books are processing
     useEffect(() => {
@@ -268,31 +269,65 @@ const ProcessingPage: React.FC = () => {
                     <p className="text-muted">No completed books yet.</p>
                 ) : (
                     <div className="list-group">
-                        {recentlyCompleted.map(book => (
-                            <Link
-                                key={book.id}
-                                to={`/books/${book.id}`}
-                                className="list-group-item list-group-item-action d-flex align-items-center gap-3"
-                            >
-                                {book.cover_image_link && (
-                                    <img
-                                        src={book.cover_image_link}
-                                        alt=""
-                                        width={40}
-                                        height={40}
-                                        style={{ objectFit: 'cover', borderRadius: 4 }}
-                                    />
-                                )}
-                                <div>
-                                    <strong>{book.title}</strong>
-                                    {book.authors[0] && (
-                                        <span className="text-muted ms-2">
-                                            {book.authors[0].first_name} {book.authors[0].last_name}
-                                        </span>
+                        {recentlyCompleted.map(book => {
+                            const isExpanded = expandedCompleted.has(book.id);
+                            const toggleExpand = (e: React.MouseEvent) => {
+                                e.preventDefault();
+                                setExpandedCompleted(prev => {
+                                    const next = new Set(prev);
+                                    next.has(book.id) ? next.delete(book.id) : next.add(book.id);
+                                    return next;
+                                });
+                            };
+                            return (
+                                <div key={book.id} className="list-group-item">
+                                    <div className="d-flex align-items-center gap-3">
+                                        <Link
+                                            to={`/books/${book.id}`}
+                                            className="d-flex align-items-center gap-3 flex-grow-1 text-decoration-none text-reset"
+                                            style={{ minWidth: 0 }}
+                                        >
+                                            {book.cover_image_link && (
+                                                <img
+                                                    src={book.cover_image_link}
+                                                    alt=""
+                                                    width={40}
+                                                    height={40}
+                                                    style={{ objectFit: 'cover', borderRadius: 4, flexShrink: 0 }}
+                                                />
+                                            )}
+                                            <div style={{ minWidth: 0 }}>
+                                                <strong className="d-block text-truncate">{book.title}</strong>
+                                                {book.authors[0] && (
+                                                    <span className="text-muted small">
+                                                        {book.authors[0].first_name} {book.authors[0].last_name}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </Link>
+                                        {book.status.message && (
+                                            <button
+                                                className="btn btn-link btn-sm p-0 flex-shrink-0 text-muted"
+                                                title={isExpanded ? 'Hide log' : 'Show log'}
+                                                onClick={toggleExpand}
+                                            >
+                                                <i className={`fas fa-chevron-${isExpanded ? 'up' : 'down'}`} />
+                                            </button>
+                                        )}
+                                    </div>
+                                    {isExpanded && book.status.message && (
+                                        <div className="mt-2 pt-2 border-top">
+                                            <pre
+                                                className="small bg-black bg-opacity-10 rounded p-2 mb-0"
+                                                style={{ whiteSpace: 'pre-wrap', fontSize: '0.75rem', maxHeight: 300, overflowY: 'auto' }}
+                                            >
+                                                {book.status.message}
+                                            </pre>
+                                        </div>
                                     )}
                                 </div>
-                            </Link>
-                        ))}
+                            );
+                        })}
                     </div>
                 )}
             </section>

--- a/frontend/src/pages/ProcessingPage.tsx
+++ b/frontend/src/pages/ProcessingPage.tsx
@@ -74,7 +74,12 @@ const ProcessingPage: React.FC = () => {
                             const logLines = book.status.message
                                 ? book.status.message.split('\n').filter(Boolean)
                                 : [];
-                            const lastLine = logLines[logLines.length - 1] ?? '';
+                            // Show the last milestone line ([HH:MM:SS] prefix) inline;
+                            // fall back to the last raw line if no milestone exists yet.
+                            const milestoneLines = logLines.filter(l => /^\[\d{2}:\d{2}:\d{2}\]/.test(l));
+                            const lastLine = milestoneLines[milestoneLines.length - 1]
+                                ?? logLines[logLines.length - 1]
+                                ?? '';
                             const runtimeHours = Math.floor(book.runtime_length_minutes / 60);
                             const runtimeMins = book.runtime_length_minutes % 60;
                             const runtimeStr = runtimeHours > 0
@@ -123,7 +128,7 @@ const ProcessingPage: React.FC = () => {
                                     {lastLine && (
                                         <div className="text-muted small mt-1">
                                             <i className="fas fa-circle-info me-1" />
-                                            {lastLine.replace(/^\[\d+:\d+:\d+\] /, '')}
+                                            {lastLine}
                                         </div>
                                     )}
                                     {isExpanded && (

--- a/frontend/src/pages/ProcessingPage.tsx
+++ b/frontend/src/pages/ProcessingPage.tsx
@@ -10,6 +10,9 @@ const ProcessingPage: React.FC = () => {
     const [reprocessAsin, setReprocessAsin] = useState('');
     const [reprocessError, setReprocessError] = useState<string | null>(null);
     const [expandedLogs, setExpandedLogs] = useState<Set<number>>(new Set());
+    const [confirmCancelId, setConfirmCancelId] = useState<number | null>(null);
+    const [cancellingId, setCancellingId] = useState<number | null>(null);
+    const [expandedProcessing, setExpandedProcessing] = useState<Set<number>>(new Set());
 
     // 1-second poll while this page is open and books are processing
     useEffect(() => {
@@ -17,6 +20,19 @@ const ProcessingPage: React.FC = () => {
         const id = setInterval(refreshBooks, 1_000);
         return () => clearInterval(id);
     }, [books.processing.length, refreshBooks]);
+
+    const handleCancel = async (bookId: number) => {
+        try {
+            setCancellingId(bookId);
+            await bookApi.cancel(bookId);
+            await refreshBooks();
+        } catch (err) {
+            console.error('Cancel failed:', getErrorMessage(err));
+        } finally {
+            setCancellingId(null);
+            setConfirmCancelId(null);
+        }
+    };
 
     const handleReprocess = async (bookId: number, asin?: string) => {
         try {
@@ -52,11 +68,23 @@ const ProcessingPage: React.FC = () => {
                             const elapsedStr = elapsed < 60
                                 ? `${elapsed}s`
                                 : `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`;
+                            const isConfirming = confirmCancelId === book.id;
+                            const isCancelling = cancellingId === book.id;
+                            const isExpanded = expandedProcessing.has(book.id);
+                            const logLines = book.status.message
+                                ? book.status.message.split('\n').filter(Boolean)
+                                : [];
+                            const lastLine = logLines[logLines.length - 1] ?? '';
+                            const runtimeHours = Math.floor(book.runtime_length_minutes / 60);
+                            const runtimeMins = book.runtime_length_minutes % 60;
+                            const runtimeStr = runtimeHours > 0
+                                ? `${runtimeHours}h ${runtimeMins}m`
+                                : `${runtimeMins}m`;
                             return (
                                 <div key={book.id} className="list-group-item">
                                     <div className="d-flex align-items-center gap-3 mb-2">
-                                        <div className="flex-grow-1">
-                                            <div className="fw-bold">{book.title}</div>
+                                        <div className="flex-grow-1" style={{ minWidth: 0 }}>
+                                            <div className="fw-bold text-truncate">{book.title}</div>
                                             {book.authors[0] && (
                                                 <div className="text-muted small">
                                                     {book.authors[0].first_name} {book.authors[0].last_name}
@@ -64,6 +92,26 @@ const ProcessingPage: React.FC = () => {
                                             )}
                                         </div>
                                         <span className="text-muted small flex-shrink-0">{elapsedStr}</span>
+                                        <button
+                                            className="btn btn-link btn-sm p-0 flex-shrink-0 text-muted"
+                                            title={isExpanded ? 'Hide details' : 'Show details'}
+                                            onClick={() => setExpandedProcessing(prev => {
+                                                const next = new Set(prev);
+                                                next.has(book.id) ? next.delete(book.id) : next.add(book.id);
+                                                return next;
+                                            })}
+                                        >
+                                            <i className={`fas fa-chevron-${isExpanded ? 'up' : 'down'}`} />
+                                        </button>
+                                        {!isConfirming && (
+                                            <button
+                                                className="btn btn-outline-danger btn-sm flex-shrink-0"
+                                                title="Cancel job"
+                                                onClick={() => setConfirmCancelId(book.id)}
+                                            >
+                                                <i className="fas fa-times" />
+                                            </button>
+                                        )}
                                     </div>
                                     <div className="progress mb-1" style={{ height: 6 }}>
                                         <div
@@ -72,10 +120,62 @@ const ProcessingPage: React.FC = () => {
                                             style={{ width: '100%' }}
                                         />
                                     </div>
-                                    {book.status.message && (
+                                    {lastLine && (
                                         <div className="text-muted small mt-1">
                                             <i className="fas fa-circle-info me-1" />
-                                            {book.status.message}
+                                            {lastLine.replace(/^\[\d+:\d+:\d+\] /, '')}
+                                        </div>
+                                    )}
+                                    {isExpanded && (
+                                        <div className="mt-3 border-top pt-3">
+                                            <div className="row g-2 mb-3 small text-muted">
+                                                <div className="col-sm-6">
+                                                    <span className="fw-semibold">ASIN: </span>{book.asin}
+                                                </div>
+                                                <div className="col-sm-6">
+                                                    <span className="fw-semibold">Runtime: </span>
+                                                    {book.runtime_length_minutes > 0 ? runtimeStr : 'Unknown'}
+                                                </div>
+                                                <div className="col-12">
+                                                    <span className="fw-semibold">Source: </span>
+                                                    <span className="font-monospace" style={{ wordBreak: 'break-all' }}>
+                                                        {book.src_path}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            {logLines.length > 0 && (
+                                                <>
+                                                    <div className="small fw-semibold text-muted mb-1">Processing log</div>
+                                                    <pre
+                                                        className="small bg-black bg-opacity-10 rounded p-2 mb-0"
+                                                        style={{ whiteSpace: 'pre-wrap', fontSize: '0.75rem', maxHeight: 200, overflowY: 'auto' }}
+                                                    >
+                                                        {logLines.join('\n')}
+                                                    </pre>
+                                                </>
+                                            )}
+                                        </div>
+                                    )}
+                                    {isConfirming && (
+                                        <div className="d-flex align-items-center gap-2 mt-2">
+                                            <span className="small text-danger">Cancel this job?</span>
+                                            <button
+                                                className="btn btn-danger btn-sm"
+                                                disabled={isCancelling}
+                                                onClick={() => handleCancel(book.id)}
+                                            >
+                                                {isCancelling
+                                                    ? <span className="spinner-border spinner-border-sm" role="status" />
+                                                    : 'Yes, cancel'
+                                                }
+                                            </button>
+                                            <button
+                                                className="btn btn-outline-secondary btn-sm"
+                                                disabled={isCancelling}
+                                                onClick={() => setConfirmCancelId(null)}
+                                            >
+                                                No
+                                            </button>
                                         </div>
                                     )}
                                 </div>

--- a/importer/api/books.py
+++ b/importer/api/books.py
@@ -268,6 +268,24 @@ class BookChaptersAPI(JsonLoginRequiredMixin, View):
         return JsonResponse({'ok': True})
 
 
+class BookCancelAPI(JsonLoginRequiredMixin, View):
+    def post(self, request, pk):
+        try:
+            book = Book.objects.select_related('status').get(pk=pk)
+        except Book.DoesNotExist:
+            return JsonResponse({'error': 'Book not found'}, status=404)
+
+        if book.status.status != StatusChoices.PROCESSING:
+            return JsonResponse({'error': 'Book is not currently processing'}, status=400)
+
+        book.status.status = StatusChoices.ERROR
+        book.status.message = 'Cancelled by user'
+        book.status.save()
+
+        logger.info("Book %s (%s) cancelled by user", pk, book.title)
+        return JsonResponse({'success': True})
+
+
 class BookCoverAPI(JsonLoginRequiredMixin, View):
     def post(self, request, pk):
         try:

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -6,7 +6,7 @@ from .api.auth import (
     PasskeyLoginBeginAPI, PasskeyLoginCompleteAPI,
     PasskeyRegisterBeginAPI, PasskeyRegisterCompleteAPI,
 )
-from .api.books import BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI, BookCoverAPI
+from .api.books import BookCancelAPI, BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI, BookCoverAPI
 from .api.config import SettingsAPI, SettingsVerifyAPI, VersionsAPI
 from .api.import_pipeline import AsinSearchAPI, DirectoryListAPI, ImportStartAPI, MatchAPI
 from .api.users import UserDetailAPI, UsersListAPI
@@ -31,6 +31,7 @@ api_patterns = [
     # Books
     path('api/books/', BooksListAPI.as_view(), name='api-books'),
     path('api/books/<int:pk>/', BookDetailAPI.as_view(), name='api-book-detail'),
+    path('api/books/<int:pk>/cancel/', BookCancelAPI.as_view(), name='api-book-cancel'),
     path('api/books/<int:pk>/reprocess/', BookReprocessAPI.as_view(), name='api-book-reprocess'),
     path('api/books/<int:pk>/metadata/', BookMetadataAPI.as_view(), name='api-book-metadata'),
     path('api/books/<int:pk>/chapters/', BookChaptersAPI.as_view(), name='api-book-chapters'),

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -79,7 +79,10 @@ class BragiM4bMerge(m4b_helper.M4bMerge):
 
 
 def _update_status_message(book, message):
-    book.status.message = message
+    from datetime import datetime
+    timestamp = datetime.now().strftime('%H:%M:%S')
+    line = f"[{timestamp}] {message}"
+    book.status.message = (book.status.message + '\n' + line).lstrip('\n')
     book.status.save(update_fields=['message'])
 
 
@@ -111,6 +114,8 @@ def run_m4b_merge(asin: str):
     logger.debug(f'Using output format: {config.path_format}')
 
     book = Book.objects.get(asin=asin)
+    book.status.message = ""
+    book.status.save(update_fields=['message'])
     setting = Setting.load()
     logger.info(
         f"{'-' * 15} Starting to process {asin}: {book.title} {'-' * 15}")
@@ -154,6 +159,12 @@ def run_m4b_merge(asin: str):
             traceback.format_exc() if settings.DEBUG else str(e)
         book.status.message = message
         book.status.save()
+        return
+
+    # Re-fetch status in case user cancelled while m4b-tool was running
+    book.status.refresh_from_db()
+    if book.status.status != StatusChoices.PROCESSING:
+        logger.info("Book %s was cancelled during processing, skipping DONE", asin)
         return
 
     book.dest_path = (

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -217,14 +217,10 @@ def run_m4b_merge(asin: str):
         logger.info("Book %s was cancelled during processing, skipping DONE", asin)
         return
 
-    book.dest_path = (
-        f"{m4b.book_output}/"
-        f"{metadata['authors'][0]}/"
-        f"{book.title}/"
-        f"{book.title}.m4b"
-    )
+    book.dest_path = f"{m4b.book_output}.m4b"
     book.status.status = StatusChoices.DONE
     book.status.save(update_fields=['status'])
+    book.save(update_fields=['dest_path'])
     logger.info(f"{'-' * 15} Done processing {asin} {'-' * 15}")
 
 

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -224,8 +224,7 @@ def run_m4b_merge(asin: str):
         f"{book.title}.m4b"
     )
     book.status.status = StatusChoices.DONE
-    book.status.message = ""
-    book.status.save()
+    book.status.save(update_fields=['status'])
     logger.info(f"{'-' * 15} Done processing {asin} {'-' * 15}")
 
 

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 import traceback
 from datetime import datetime
 from pathlib import Path
@@ -18,9 +19,57 @@ logger = logging.getLogger(__name__)
 class BragiM4bMerge(m4b_helper.M4bMerge):
     """M4bMerge subclass that applies Bragi's Setting overrides."""
 
-    def __init__(self, input_data, metadata, original_path, chapters=None, setting=None):
+    def __init__(self, input_data, metadata, original_path, chapters=None, setting=None, book=None):
         super().__init__(input_data, metadata, original_path, chapters)
         self._setting = setting
+        self._book = book
+        self._log_buffer = []
+        self._last_flush = datetime.min
+
+    def _log_subprocess_line(self, line):
+        self._log_buffer.append(line)
+        now = datetime.now()
+        if (now - self._last_flush).total_seconds() >= 2:
+            self._flush_log_buffer()
+            self._last_flush = now
+
+    def _flush_log_buffer(self):
+        if not self._log_buffer or not self._book:
+            self._log_buffer = []
+            return
+        chunk = '\n'.join(self._log_buffer)
+        self._book.status.message = (self._book.status.message + '\n' + chunk).lstrip('\n')
+        self._book.status.save(update_fields=['message'])
+        self._log_buffer = []
+
+    def run_merge(self):
+        original_call = subprocess.call
+
+        def capturing_call(args, **kwargs):
+            logger.info(f"M4B command: {args}")
+            kwargs.pop('stdout', None)
+            kwargs.pop('stderr', None)
+            proc = subprocess.Popen(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                **kwargs,
+            )
+            for line in proc.stdout:
+                line = line.rstrip('\n')
+                if line:
+                    self._log_subprocess_line(line)
+            proc.wait()
+            self._flush_log_buffer()
+            return proc.returncode
+
+        subprocess.call = capturing_call
+        try:
+            super().run_merge()
+        finally:
+            subprocess.call = original_call
+            self._flush_log_buffer()
 
     def prepare_command_args(self):
         super().prepare_command_args()
@@ -147,6 +196,7 @@ def run_m4b_merge(asin: str):
             Path(book.src_path),
             chapters,
             setting=setting,
+            book=book,
         )
 
         _update_status_message(book, "Merging audio files (this may take a while)…")


### PR DESCRIPTION
## Summary

- **Expandable cards** — each processing card has a chevron (▼) that reveals ASIN, source path, runtime, and a scrollable timestamped milestone log
- **Inline status** — the latest log line is always visible under the progress bar without expanding
- **Cancel button** — a × button shows an inline confirm; confirming POSTs to `POST /api/books/<id>/cancel/` and moves the book to the Errors section immediately
- **Worker guard** — `run_m4b_merge()` re-checks status before writing DONE, so cancelling a job that's already mid-merge is respected when the worker finishes

## Changes

**Backend**
- `importer/api/books.py` — new `BookCancelAPI` view
- `importer/urls.py` — registers `api/books/<id>/cancel/`
- `utils/merge.py` — `_update_status_message` now appends timestamped lines instead of overwriting; log cleared at start of each run; post-merge guard re-checks status before DONE

**Frontend**
- `frontend/src/api/services.ts` — `bookApi.cancel(id)`
- `frontend/src/pages/ProcessingPage.tsx` — expand state, chevron toggle, log panel, cancel flow

## Test plan

- [ ] Start a processing job, confirm milestone lines appear with timestamps in the expanded panel
- [ ] Confirm inline status (last log line) updates as stages progress
- [ ] Cancel a stuck job — confirm it moves to Errors section with "Cancelled by user"
- [ ] Verify re-processing a cancelled job works normally