### PR TITLE
feat: server side pagination, filtering, and sorting

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -45,10 +45,31 @@ export const directoryApi = {
     },
 };
 
+export interface LibraryParams {
+    page?: number;
+    page_size?: number;
+    sort?: 'title' | 'release_date' | 'author' | 'recently_added';
+    order?: 'asc' | 'desc';
+    q?: string;
+}
+
+export interface LibraryPage {
+    count: number;
+    page: number;
+    page_size: number;
+    total_pages: number;
+    results: Book[];
+}
+
 // Book operations
 export const bookApi = {
     getAll: async (): Promise<{ done: Book[]; processing: Book[]; error: Book[] }> => {
         const response = await apiClient.get('/api/books/');
+        return response.data;
+    },
+
+    getLibrary: async (params: LibraryParams = {}): Promise<LibraryPage> => {
+        const response = await apiClient.get<LibraryPage>('/api/books/library/', { params });
         return response.data;
     },
 

--- a/frontend/src/context/DataContext.tsx
+++ b/frontend/src/context/DataContext.tsx
@@ -58,16 +58,17 @@ export const DataProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             // Detect PROCESSING → DONE or ERROR transitions
             const prevIds = new Set(prevProcessingRef.current.map(b => b.id));
             const prevById = new Map(prevProcessingRef.current.map(b => [b.id, b]));
-            const nowDoneIds = new Set(data.done.map(b => b.id));
+            const nowProcessingIds = new Set(data.processing.map(b => b.id));
             const nowErrorIds = new Set(data.error.map(b => b.id));
 
             const newToasts: Toast[] = [];
             for (const id of prevIds) {
                 const prev = prevById.get(id)!;
-                if (nowDoneIds.has(id)) {
-                    newToasts.push({ id: ++toastCounter, type: 'done', bookId: id, title: prev.title });
-                } else if (nowErrorIds.has(id)) {
+                if (nowErrorIds.has(id)) {
                     newToasts.push({ id: ++toastCounter, type: 'error', bookId: id, title: prev.title });
+                } else if (!nowProcessingIds.has(id)) {
+                    // Was processing, not in error → must be done
+                    newToasts.push({ id: ++toastCounter, type: 'done', bookId: id, title: prev.title });
                 }
             }
             if (newToasts.length > 0) {
@@ -110,11 +111,14 @@ export const DataProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         refreshSettings();
     }, []);
 
-    // Poll every 10s while books are processing
+    // When processing empties, do one follow-up fetch after a short delay so
+    // books that just finished (backend still committing) land in recently completed.
     useEffect(() => {
-        if (books.processing.length > 0) {
-            const interval = setInterval(refreshBooks, 10_000);
-            return () => clearInterval(interval);
+        const prev = prevProcessingLengthRef.current;
+        prevProcessingLengthRef.current = books.processing.length;
+        if (prev > 0 && books.processing.length === 0) {
+            const timer = setTimeout(refreshBooks, 1500);
+            return () => clearTimeout(timer);
         }
     }, [books.processing.length, refreshBooks]);
 

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -1,17 +1,23 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import LibraryBookCard from '../components/LibraryBookCard';
 import Pagination from '../components/Pagination';
-import { useData } from '../context/DataContext';
+import { bookApi } from '../api/services';
+import type { LibraryPage } from '../api/services';
 
 type SortOption = 'title' | 'release_date' | 'author' | 'recently_added';
 
+const DEFAULT_ORDER: Record<SortOption, 'asc' | 'desc'> = {
+    title: 'asc',
+    release_date: 'desc',
+    author: 'asc',
+    recently_added: 'desc',
+};
+
 const BooksPage: React.FC = () => {
     const location = useLocation();
-    const { books, loadingBooks, errorBooks } = useData();
 
-    // Filter/Sort/Pagination state - restore from location.state if available
     const [searchQuery, setSearchQuery] = useState(
         (location.state as any)?.searchQuery || ''
     );
@@ -25,62 +31,66 @@ const BooksPage: React.FC = () => {
         (location.state as any)?.currentPage || 1
     );
     const [searchFocused, setSearchFocused] = useState(false);
+    const [libraryData, setLibraryData] = useState<LibraryPage | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
-    // Scroll to top when page changes
+    const prevSearchRef = useRef(searchQuery);
+
+    const fetchLibrary = useCallback(async (params: {
+        page: number; page_size: number; sort: SortOption;
+        order: 'asc' | 'desc'; q: string;
+    }) => {
+        try {
+            setLoading(true);
+            const data = await bookApi.getLibrary(params);
+            setLibraryData(data);
+            setError(null);
+        } catch (err: any) {
+            setError(err?.response?.data?.error || err?.message || 'Failed to load library');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        const searchChanged = prevSearchRef.current !== searchQuery;
+        prevSearchRef.current = searchQuery;
+
+        if (searchChanged) {
+            const timer = setTimeout(() => {
+                setCurrentPage(1);
+                fetchLibrary({
+                    page: 1,
+                    page_size: itemsPerPage,
+                    sort: sortBy,
+                    order: DEFAULT_ORDER[sortBy],
+                    q: searchQuery,
+                });
+            }, 300);
+            return () => clearTimeout(timer);
+        } else {
+            fetchLibrary({
+                page: currentPage,
+                page_size: itemsPerPage,
+                sort: sortBy,
+                order: DEFAULT_ORDER[sortBy],
+                q: searchQuery,
+            });
+        }
+    }, [searchQuery, sortBy, itemsPerPage, currentPage]);
+
+    // Reset to page 1 when sort or page size changes
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [sortBy, itemsPerPage]);
+
+    // Scroll to top on page change
     useEffect(() => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     }, [currentPage]);
 
-    // Filter and sort books
-    const filteredAndSortedBooks = useMemo(() => {
-        let result = [...(books.done ?? [])];
-
-        // Filter by search query
-        if (searchQuery) {
-            const query = searchQuery.toLowerCase();
-            result = result.filter(book => {
-                const authors = book.authors.map(a => `${a.first_name} ${a.last_name}`.toLowerCase()).join(' ');
-                return (
-                    book.title.toLowerCase().includes(query) ||
-                    authors.includes(query)
-                );
-            });
-        }
-
-        // Sort books
-        result.sort((a, b) => {
-            switch (sortBy) {
-                case 'title':
-                    return a.title.localeCompare(b.title);
-                case 'release_date':
-                    return new Date(b.release_date).getTime() - new Date(a.release_date).getTime();
-                case 'author':
-                    const authorA = a.authors[0] ? `${a.authors[0].last_name} ${a.authors[0].first_name}` : '';
-                    const authorB = b.authors[0] ? `${b.authors[0].last_name} ${b.authors[0].first_name}` : '';
-                    return authorA.localeCompare(authorB);
-                case 'recently_added':
-                    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-                default:
-                    return 0;
-            }
-        });
-
-        return result;
-    }, [books.done, searchQuery, sortBy]);
-
-    // Paginate books
-    const totalPages = Math.ceil(filteredAndSortedBooks.length / itemsPerPage);
-    const paginatedBooks = filteredAndSortedBooks.slice(
-        (currentPage - 1) * itemsPerPage,
-        currentPage * itemsPerPage
-    );
-
-    // Reset to page 1 when filters change
-    useEffect(() => {
-        setCurrentPage(1);
-    }, [searchQuery, sortBy, itemsPerPage]);
-
-    if (loadingBooks) {
+    if (loading && !libraryData) {
         return (
             <div className="d-flex justify-content-center align-items-center" style={{ minHeight: '300px' }}>
                 <div className="spinner-border text-primary" role="status">
@@ -90,15 +100,15 @@ const BooksPage: React.FC = () => {
         );
     }
 
-    if (errorBooks) {
+    if (error) {
         return (
             <div className="alert alert-danger m-4" role="alert">
-                {errorBooks}
+                {error}
             </div>
         );
     }
 
-    if (books.done.length === 0) {
+    if (libraryData && libraryData.count === 0 && !searchQuery) {
         return (
             <div className="library-page">
                 <PageHeader title="My Library" />
@@ -114,9 +124,13 @@ const BooksPage: React.FC = () => {
         );
     }
 
+    const totalPages = libraryData?.total_pages ?? 1;
+    const books = libraryData?.results ?? [];
+    const totalCount = libraryData?.count ?? 0;
+
     return (
         <div className="library-page">
-            <PageHeader title={`My Library (${filteredAndSortedBooks.length})`}>
+            <PageHeader title={`My Library (${totalCount})`}>
                 <div className="library-controls">
                     {/* Search Bar - expandable on focus */}
                     <div className={`library-search ${searchFocused ? 'focused' : ''}`}>
@@ -140,7 +154,7 @@ const BooksPage: React.FC = () => {
                         )}
                     </div>
 
-                    {/* Sort Icon (Unified for Mobile & Desktop) */}
+                    {/* Sort Icon */}
                     <div className="sort-wrapper ms-2" title="Sort books">
                         <i className="fa-solid fa-arrow-down-short-wide text-gold"></i>
                         <select
@@ -155,16 +169,14 @@ const BooksPage: React.FC = () => {
                             <option value="recently_added">Recently Added</option>
                         </select>
                     </div>
-
-
                 </div>
             </PageHeader>
 
             {/* Library Grid */}
-            {paginatedBooks.length > 0 ? (
+            {books.length > 0 ? (
                 <>
                     <div className="library-grid">
-                        {paginatedBooks.map(book => (
+                        {books.map(book => (
                             <LibraryBookCard
                                 key={book.id}
                                 book={book}

--- a/importer/api/books.py
+++ b/importer/api/books.py
@@ -5,6 +5,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
+from django.db import models
+from django.db.models import Min
 from django.http import JsonResponse
 from django.views import View
 
@@ -85,9 +87,6 @@ def serialize_book(book: Book) -> dict:
 class BooksListAPI(JsonLoginRequiredMixin, View):
     def get(self, request):
         try:
-            done_books = Book.objects.filter(
-                status__status=StatusChoices.DONE
-            ).order_by('-created_at')
             processing_books = Book.objects.filter(
                 status__status=StatusChoices.PROCESSING
             ).order_by('-created_at')
@@ -95,13 +94,64 @@ class BooksListAPI(JsonLoginRequiredMixin, View):
                 status__status=StatusChoices.ERROR
             ).order_by('-created_at')
             return JsonResponse({
-                'done': [serialize_book(b) for b in done_books],
+                'done': [],
                 'processing': [serialize_book(b) for b in processing_books],
                 'error': [serialize_book(b) for b in error_books],
             })
         except Exception as e:
             logger.error("Error fetching books: %s", e)
             return JsonResponse({'error': str(e)}, status=500)
+
+
+class LibraryBooksAPI(JsonLoginRequiredMixin, View):
+    SORT_MAP = {
+        'title': 'title',
+        'release_date': 'release_date',
+        'author': 'author_last',
+        'recently_added': 'created_at',
+    }
+
+    def get(self, request):
+        try:
+            page = max(1, int(request.GET.get('page', 1)))
+            page_size = min(100, max(1, int(request.GET.get('page_size', 25))))
+            sort = request.GET.get('sort', 'title')
+            order = request.GET.get('order', 'asc')
+            q = request.GET.get('q', '').strip()
+        except (ValueError, TypeError):
+            return JsonResponse({'error': 'Invalid query parameters'}, status=400)
+
+        sort_field = self.SORT_MAP.get(sort, 'title')
+        order_prefix = '-' if order == 'desc' else ''
+
+        books = Book.objects.filter(status__status=StatusChoices.DONE)
+
+        if q:
+            books = books.filter(
+                models.Q(title__icontains=q) |
+                models.Q(authors__last_name__icontains=q) |
+                models.Q(authors__first_name__icontains=q)
+            ).distinct()
+
+        if sort_field == 'author_last':
+            books = books.annotate(author_last=Min('authors__last_name'))
+
+        books = books.order_by(f'{order_prefix}{sort_field}')
+
+        count = books.count()
+        total_pages = max(1, (count + page_size - 1) // page_size)
+        page = min(page, total_pages)
+
+        offset = (page - 1) * page_size
+        page_books = list(books[offset:offset + page_size])
+
+        return JsonResponse({
+            'count': count,
+            'page': page,
+            'page_size': page_size,
+            'total_pages': total_pages,
+            'results': [serialize_book(b) for b in page_books],
+        })
 
 
 class BookDetailAPI(JsonLoginRequiredMixin, View):

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -6,7 +6,7 @@ from .api.auth import (
     PasskeyLoginBeginAPI, PasskeyLoginCompleteAPI,
     PasskeyRegisterBeginAPI, PasskeyRegisterCompleteAPI,
 )
-from .api.books import BookCancelAPI, BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI, BookCoverAPI
+from .api.books import BookCancelAPI, BookDetailAPI, BookMetadataAPI, BookReprocessAPI, BooksListAPI, BookChaptersAPI, BookCoverAPI, LibraryBooksAPI
 from .api.config import SettingsAPI, SettingsVerifyAPI, VersionsAPI
 from .api.import_pipeline import AsinSearchAPI, DirectoryListAPI, ImportStartAPI, MatchAPI
 from .api.users import UserDetailAPI, UsersListAPI
@@ -29,6 +29,7 @@ api_patterns = [
     path('api/auth/passkeys/<int:pk>/', PasskeyDeleteAPI.as_view(), name='api-passkey-delete'),
 
     # Books
+    path('api/books/library/', LibraryBooksAPI.as_view(), name='api-books-library'),
     path('api/books/', BooksListAPI.as_view(), name='api-books'),
     path('api/books/<int:pk>/', BookDetailAPI.as_view(), name='api-book-detail'),
     path('api/books/<int:pk>/cancel/', BookCancelAPI.as_view(), name='api-book-cancel'),


### PR DESCRIPTION
Backend (importer/api/books.py):
  - BooksListAPI.get now returns done: [], processing: [...], error: [...] — no more full library dump
  - New LibraryBooksAPI at GET /api/books/library/ with page, page_size, sort, order, q params, server-side filtering/sorting/pagination over done books

  Frontend:
  - DataContext — removed the 10-second poll; toast detection now infers DONE by "was processing, not in error → must be done" (no longer needs data.done to be populated)
  - services.ts — added LibraryParams, LibraryPage types and bookApi.getLibrary()
  - BooksPage.tsx — completely standalone: fetches its own paginated data directly, debounces search (300ms), resets to page 1 on sort/filter changes, no longer reads from DataContext at all