### PR TITLE
ci: pin dockerhub-description action to full commit SHA

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
 
             - name: Update Docker Hub Description
               if: github.ref == 'refs/heads/main'
-              uses: peter-evans/dockerhub-description@v5
+              uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
               with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary
- Pins `peter-evans/dockerhub-description` from the mutable `v5` tag to its full 40-char commit SHA (`1b9a80c`) to prevent supply chain attacks via tag mutation
- Keeps `# v5` comment for readability

## Test plan
- [ ] Verify CI passes on merge
- [ ] Confirm Docker Hub description still updates on next push to main