### PR TITLE
ci: add semver Docker tags and manual release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,58 @@
+name: Create Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to release (semver, no "v" prefix — e.g. 2.1.0)'
+                required: true
+                type: string
+            prerelease:
+                description: 'Mark as pre-release'
+                required: false
+                default: false
+                type: boolean
+
+jobs:
+    create-release:
+        name: Tag and publish release
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+
+            - name: Validate version format
+              env:
+                  VERSION: ${{ github.event.inputs.version }}
+              run: |
+                  if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                      echo "Error: version must be semver format with no leading 'v' (e.g. 2.1.0)"
+                      exit 1
+                  fi
+
+            - name: Create tag and GitHub release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ github.event.inputs.version }}
+                  PRERELEASE: ${{ github.event.inputs.prerelease }}
+              run: |
+                  TAG="v${VERSION}"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git tag "$TAG"
+                  git push origin "$TAG"
+
+                  PRERELEASE_FLAG=""
+                  if [ "$PRERELEASE" = "true" ]; then
+                      PRERELEASE_FLAG="--prerelease"
+                  fi
+
+                  # --generate-notes uses GitHub's auto-generated release notes
+                  # Pushing the tag above will also trigger docker-publish.yml automatically
+                  gh release create "$TAG" \
+                      --title "$TAG" \
+                      --generate-notes \
+                      $PRERELEASE_FLAG

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,11 +4,16 @@ on:
     workflow_dispatch:
         inputs:
             version:
-                description: 'Version to release (semver, no "v" prefix — e.g. 2.1.0)'
+                description: 'Version (no "v" prefix — e.g. 2.1.0  or  2.1.0-beta.1  or  2.1.0-rc.2)'
                 required: true
                 type: string
+            branch:
+                description: 'Branch to tag (e.g. main, develop, release/2.1)'
+                required: false
+                default: 'main'
+                type: string
             prerelease:
-                description: 'Mark as pre-release'
+                description: 'Mark as pre-release (auto-set when version contains a suffix like -beta or -rc)'
                 required: false
                 default: false
                 type: boolean
@@ -21,23 +26,32 @@ jobs:
             contents: write
 
         steps:
-            - name: Check out the repo
-              uses: actions/checkout@v4
-
-            - name: Validate version format
+            - name: Validate inputs
               env:
                   VERSION: ${{ github.event.inputs.version }}
+                  BRANCH: ${{ github.event.inputs.branch }}
               run: |
-                  if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-                      echo "Error: version must be semver format with no leading 'v' (e.g. 2.1.0)"
+                  # Semver with optional pre-release suffix: 2.1.0 or 2.1.0-beta.1 or 2.1.0-rc.2
+                  if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?$'; then
+                      echo "Error: version must be semver format (e.g. 2.1.0 or 2.1.0-beta.1)"
                       exit 1
                   fi
+                  # Branch name: allow letters, digits, /, -, _, .
+                  if ! echo "$BRANCH" | grep -qE '^[a-zA-Z0-9/_.-]+$'; then
+                      echo "Error: branch name contains invalid characters"
+                      exit 1
+                  fi
+
+            - name: Check out the repo
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.inputs.branch }}
 
             - name: Create tag and GitHub release
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   VERSION: ${{ github.event.inputs.version }}
-                  PRERELEASE: ${{ github.event.inputs.prerelease }}
+                  PRERELEASE_INPUT: ${{ github.event.inputs.prerelease }}
               run: |
                   TAG="v${VERSION}"
                   git config user.name "github-actions[bot]"
@@ -45,13 +59,14 @@ jobs:
                   git tag "$TAG"
                   git push origin "$TAG"
 
+                  # Auto-mark as pre-release if the version string contains a suffix (-beta, -rc, etc.)
+                  # The checkbox can also force pre-release for a clean version number.
                   PRERELEASE_FLAG=""
-                  if [ "$PRERELEASE" = "true" ]; then
+                  if echo "$VERSION" | grep -q '-' || [ "$PRERELEASE_INPUT" = "true" ]; then
                       PRERELEASE_FLAG="--prerelease"
                   fi
 
-                  # --generate-notes uses GitHub's auto-generated release notes
-                  # Pushing the tag above will also trigger docker-publish.yml automatically
+                  # Pushing the tag above automatically triggers docker-publish.yml
                   gh release create "$TAG" \
                       --title "$TAG" \
                       --generate-notes \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,10 +3,8 @@ name: Publish Docker image
 on:
     workflow_dispatch:
     push:
-        branches:
-            - main
-            - develop
-        # Publish semver tags as releases.
+        # Only publish on explicit version tags — branch pushes do not trigger a release.
+        # Use the "Create Release" workflow to tag and publish.
         tags: ['v*.*.*']
 
 jobs:
@@ -44,12 +42,11 @@ jobs:
                   flavor: |
                       latest=auto
                   tags: |
-                      # semver tag v2.1.0 → image tags 2.1.0 / 2.1 / 2 / latest
+                      # stable release v2.1.0 → 2.1.0 / 2.1 / 2 / latest
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=semver,pattern={{major}}
-                      # branch pushes → main / develop
-                      type=ref,event=branch
+                      # pre-release v2.1.0-beta.1 → 2.1.0-beta.1 only (no latest / major / minor)
 
             - name: Build and push Docker images
               uses: docker/build-push-action@a8d35412fb758de9162fd63e3fa3f0942bdedb4d
@@ -61,7 +58,7 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
 
             - name: Update Docker Hub Description
-              if: github.ref == 'refs/heads/main'
+              if: "!contains(github.ref, '-')"
               uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
               with:
                 username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,16 @@ jobs:
                   images: |
                       ${{ secrets.DOCKER_USERNAME }}/bragibooks
                       ghcr.io/${{ github.repository }}
+                  # latest=auto: sets "latest" only on semver tag pushes, not branch pushes
+                  flavor: |
+                      latest=auto
+                  tags: |
+                      # semver tag v2.1.0 → image tags 2.1.0 / 2.1 / 2 / latest
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=semver,pattern={{major}}
+                      # branch pushes → main / develop
+                      type=ref,event=branch
 
             - name: Build and push Docker images
               uses: docker/build-push-action@a8d35412fb758de9162fd63e3fa3f0942bdedb4d


### PR DESCRIPTION
## Summary
- **`docker-publish.yml`**: Removed branch push triggers — Docker images now only publish when a semver tag is pushed or the workflow is manually dispatched. Branch pushes to main/develop no longer trigger a release.
- **`create-release.yml`**: Extended with branch selection and pre-release version support

## \`docker-publish.yml\` tag behavior
| Event | Docker tags produced |
|---|---|
| Tag \`v2.1.0\` | \`2.1.0\`, \`2.1\`, \`2\`, \`latest\` |
| Tag \`v2.1.0-beta.1\` | \`2.1.0-beta.1\` only (no \`latest\`, no floating tags) |
| Push to \`main\` or \`develop\` | nothing — no Docker publish |
| Manual \`workflow_dispatch\` | builds and pushes from whatever the current HEAD is |

## \`create-release.yml\` inputs
| Input | Example | Notes |
|---|---|---|
| Version | \`2.1.0\` or \`2.1.0-beta.1\` or \`2.1.0-rc.2\` | Validated as semver before tagging |
| Branch | \`main\`, \`develop\`, \`release/2.1\` | Defaults to \`main\` |
| Pre-release | checkbox | Auto-set when version contains a \`-\` suffix |

Pushing the tag from \`create-release.yml\` automatically triggers \`docker-publish.yml\`.

## Test plan
- [ ] Push to main — confirm no Docker publish fires
- [ ] Run **Create Release** with \`2.x.x\` on \`main\` — confirm stable tags (\`2.x.x\`, \`2.x\`, \`2\`, \`latest\`) appear on Docker Hub
- [ ] Run **Create Release** with \`2.x.x-beta.1\` on \`develop\` — confirm only the \`2.x.x-beta.1\` tag appears (no \`latest\`)